### PR TITLE
Add SEO and LLM-friendly routes for documentation

### DIFF
--- a/apps/docs/app/llms-full.txt/route.ts
+++ b/apps/docs/app/llms-full.txt/route.ts
@@ -1,0 +1,73 @@
+import { source } from "@/lib/source";
+import fs from "fs/promises";
+import path from "path";
+
+const baseUrl = "https://copilot-sdk.yourgpt.ai";
+
+export const revalidate = false;
+
+async function getDocFiles(): Promise<Map<string, string>> {
+  const docsDir = path.join(process.cwd(), "content/docs");
+  const files = await fs.readdir(docsDir, { recursive: true });
+  const mdxFiles = new Map<string, string>();
+
+  for (const file of files) {
+    if (typeof file === "string" && file.endsWith(".mdx")) {
+      const filePath = path.join(docsDir, file);
+      const content = await fs.readFile(filePath, "utf-8");
+      // Convert file path to URL path (e.g., "react/index.mdx" -> "/docs/react")
+      const urlPath =
+        "/docs/" + file.replace(/\/index\.mdx$/, "").replace(/\.mdx$/, "");
+      mdxFiles.set(urlPath === "/docs/" ? "/docs" : urlPath, content);
+    }
+  }
+
+  return mdxFiles;
+}
+
+export async function GET() {
+  const pages = source.getPages();
+  const docFiles = await getDocFiles();
+
+  const sections: string[] = [
+    "# YourGPT Copilot SDK - Full Documentation",
+    "",
+    "> Open-source SDK for building AI assistants with App Context Awareness.",
+    "",
+    "---",
+    "",
+  ];
+
+  for (const page of pages) {
+    const content = docFiles.get(page.url);
+
+    if (content) {
+      // Remove frontmatter
+      const contentWithoutFrontmatter = content.replace(
+        /^---[\s\S]*?---\n/,
+        "",
+      );
+      // Remove import statements
+      const cleanContent = contentWithoutFrontmatter
+        .replace(/^import\s+.*?;\n/gm, "")
+        .trim();
+
+      sections.push(`## ${page.data.title}`);
+      sections.push(`URL: ${baseUrl}${page.url}`);
+      if (page.data.description) {
+        sections.push(`Description: ${page.data.description}`);
+      }
+      sections.push("");
+      sections.push(cleanContent);
+      sections.push("");
+      sections.push("---");
+      sections.push("");
+    }
+  }
+
+  return new Response(sections.join("\n"), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/apps/docs/app/llms.txt/route.ts
+++ b/apps/docs/app/llms.txt/route.ts
@@ -1,0 +1,28 @@
+import { source } from "@/lib/source";
+
+const baseUrl = "https://copilot-sdk.yourgpt.ai";
+
+export const revalidate = false;
+
+export function GET() {
+  const pages = source.getPages();
+
+  const content = `# YourGPT Copilot SDK
+
+> Open-source SDK for building AI assistants with App Context Awareness.
+
+## Documentation Pages
+
+${pages.map((page) => `- [${page.data.title}](${baseUrl}${page.url}): ${page.data.description || ""}`).join("\n")}
+
+## Full Documentation
+
+For the complete documentation content, see: ${baseUrl}/llms-full.txt
+`;
+
+  return new Response(content, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/apps/docs/app/robots.ts
+++ b/apps/docs/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+
+const baseUrl = "https://copilot-sdk.yourgpt.ai";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from "next";
+import { source } from "@/lib/source";
+
+const baseUrl = "https://copilot-sdk.yourgpt.ai";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const pages = source.getPages();
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+    ...pages.map((page) => ({
+      url: `${baseUrl}${page.url}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: 0.8,
+    })),
+  ];
+}


### PR DESCRIPTION
## Summary
- Add `robots.ts` for search engine crawling rules
- Add `sitemap.ts` with dynamic page generation from documentation source
- Add `llms.txt` route with documentation index for AI agents
- Add `llms-full.txt` route with full documentation content for AI consumption

## New Routes
| Route | Purpose |
|-------|---------|
| `/robots.txt` | Search engine crawling rules |
| `/sitemap.xml` | Dynamic sitemap with all doc pages |
| `/llms.txt` | Index of docs for AI agents |
| `/llms-full.txt` | Full documentation content for AI |

## Test plan
- [ ] Verify `/robots.txt` returns correct format
- [ ] Verify `/sitemap.xml` includes all documentation pages
- [ ] Verify `/llms.txt` lists all pages with URLs
- [ ] Verify `/llms-full.txt` contains full documentation content

🤖 Generated with [Claude Code](https://claude.com/claude-code)