### PR TITLE
fix: use pnpm publish to properly resolve workspace protocol

### DIFF
--- a/packages/copilot-sdk/package.json
+++ b/packages/copilot-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yourgpt/copilot-sdk",
-  "version": "0.1.1",
+  "version": "1.0.1",
   "description": "Build AI copilots with app context awareness",
   "type": "module",
   "exports": {

--- a/packages/llm-sdk/package.json
+++ b/packages/llm-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yourgpt/llm-sdk",
-  "version": "0.1.1",
+  "version": "1.0.1",
   "description": "LLM SDK for YourGPT - Multi-provider LLM integration",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -99,7 +99,7 @@ for pkg in "${PACKAGES[@]}"; do
   echo -e "  Publishing $PKG_NAME@$PKG_VERSION..."
 
   cd "packages/$pkg"
-  npm publish --access public 2>&1 | grep -E "(notice|error|\+)"
+  pnpm publish --access public --no-git-checks 2>&1 | grep -E "(notice|error|\+)"
 
   if [ ${PIPESTATUS[0]} -eq 0 ]; then
     echo -e "${GREEN}  ✓ $PKG_NAME@$PKG_VERSION published${NC}"


### PR DESCRIPTION
## Summary
- Change publish.sh to use `pnpm publish` instead of `npm publish`
- This ensures `workspace:^` dependencies are replaced with actual versions
- Bump versions to 1.0.1 for republish

## Problem
The previous publish used `npm publish` which doesn't understand pnpm's workspace protocol, causing `workspace:^` to appear in the published package.json. This made the packages uninstallable with npm:

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:^
```

## Solution
Use `pnpm publish` which automatically replaces `workspace:^` with the actual version number during publish.

## Test plan
- [ ] Run `pnpm publish:sdk` after merge
- [ ] Verify with `npm view @yourgpt/llm-sdk@1.0.1 dependencies` shows `"@yourgpt/copilot-sdk": "^1.0.1"` instead of `workspace:^`

🤖 Generated with [Claude Code](https://claude.ai/code)