### PR TITLE
feat: Hybrid SDK approach - OpenAI SDK for Google/xAI providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Production-ready AI Copilots for any product. Connect any LLM, deploy on your in
 ### Install
 
 ```bash
-npm install @yourgpt/copilot-sdk @yourgpt/llm-sdk
+npm install @yourgpt/copilot-sdk @yourgpt/llm-sdk openai
 ```
 
 ### Frontend (React)
@@ -56,7 +56,7 @@ export async function POST(req: Request) {
   const { messages } = await req.json();
 
   const result = await streamText({
-    model: openai("gpt-5"),
+    model: openai("gpt-4o"),
     system: "You are a helpful assistant.",
     messages,
   });
@@ -79,17 +79,24 @@ import { google } from "@yourgpt/llm-sdk/google";
 import { xai } from "@yourgpt/llm-sdk/xai";
 
 // OpenAI
-await streamText({ model: openai("gpt-5"), messages });
+await streamText({ model: openai("gpt-4o"), messages });
 
 // Anthropic
 await streamText({ model: anthropic("claude-sonnet-4-20250514"), messages });
 
-// Google
+// Google Gemini (uses OpenAI-compatible API)
 await streamText({ model: google("gemini-2.0-flash"), messages });
 
-// xAI
-await streamText({ model: xai("grok-3"), messages });
+// xAI Grok (uses OpenAI-compatible API)
+await streamText({ model: xai("grok-3-fast-beta"), messages });
 ```
+
+### SDK Requirements
+
+| Provider            | SDK Required        |
+| ------------------- | ------------------- |
+| OpenAI, Google, xAI | `openai`            |
+| Anthropic           | `@anthropic-ai/sdk` |
 
 ### Server-Side Tools
 
@@ -101,7 +108,7 @@ import { openai } from "@yourgpt/llm-sdk/openai";
 import { z } from "zod";
 
 const result = await streamText({
-  model: openai("gpt-5"),
+  model: openai("gpt-4o"),
   messages,
   tools: {
     getWeather: tool({

--- a/apps/docs/components/quick-setup-steps.tsx
+++ b/apps/docs/components/quick-setup-steps.tsx
@@ -16,7 +16,7 @@ const steps: StepData[] = [
     title: "Install",
     description: "Add the SDK packages",
     language: "bash",
-    code: "pnpm add @yourgpt/copilot-sdk @yourgpt/llm-sdk",
+    code: "pnpm add @yourgpt/copilot-sdk @yourgpt/llm-sdk openai",
   },
   {
     title: "Backend",

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -71,11 +71,17 @@ Done. The SDK handles consent UI, captures context, sends it to the AI.
 
 | Package | What it does |
 |---------|--------------|
-| `@yourgpt/copilot-sdk/react` | Hooks + Provider. The brain. |
-| `@yourgpt/copilot-sdk/ui` | Chat components. The face. |
-| `@yourgpt/llm-sdk` | Multi-provider LLM integration + streaming. The backend. |
-| `@yourgpt/copilot-sdk/core` | Types, utils, smart context tools. The foundation. |
-| `@yourgpt/copilot-sdk-knowledge` | Knowledge base integration for RAG. (Coming Soon) |
+| `@yourgpt/copilot-sdk` | React hooks, provider, UI components, and core utilities |
+| `@yourgpt/llm-sdk` | Multi-provider LLM integration + streaming |
+
+### SDK Requirements
+
+| Provider | SDK Required |
+|----------|--------------|
+| OpenAI, Google, xAI | `openai` |
+| Anthropic | `@anthropic-ai/sdk` |
+
+Most providers use OpenAI-compatible APIs, so you only need one of 2 SDKs. [Learn more →](/docs/providers#why-only-2-sdks)
 
 ---
 
@@ -84,20 +90,24 @@ Done. The SDK handles consent UI, captures context, sends it to the AI.
 <Tabs items={['npm', 'pnpm', 'bun']}>
   <Tab value="npm">
     ```bash
-    npm install @yourgpt/copilot-sdk/react @yourgpt/copilot-sdk/ui @yourgpt/llm-sdk
+    npm install @yourgpt/copilot-sdk @yourgpt/llm-sdk openai
     ```
   </Tab>
   <Tab value="pnpm">
     ```bash
-    pnpm add @yourgpt/copilot-sdk/react @yourgpt/copilot-sdk/ui @yourgpt/llm-sdk
+    pnpm add @yourgpt/copilot-sdk @yourgpt/llm-sdk openai
     ```
   </Tab>
   <Tab value="bun">
     ```bash
-    bun add @yourgpt/copilot-sdk/react @yourgpt/copilot-sdk/ui @yourgpt/llm-sdk
+    bun add @yourgpt/copilot-sdk @yourgpt/llm-sdk openai
     ```
   </Tab>
 </Tabs>
+
+<Callout type="info">
+The `openai` SDK works with OpenAI, Google Gemini, and xAI. For Anthropic, use `@anthropic-ai/sdk` instead. [See all providers →](/docs/providers)
+</Callout>
 
 ---
 

--- a/apps/docs/content/docs/providers/anthropic.mdx
+++ b/apps/docs/content/docs/providers/anthropic.mdx
@@ -18,17 +18,23 @@ Claude models from Anthropic. Known for safety, long context, and excellent reas
 
 ## Setup
 
-### 1. Get API Key
+### 1. Install Packages
+
+```bash
+npm install @yourgpt/copilot-sdk @yourgpt/llm-sdk @anthropic-ai/sdk
+```
+
+### 2. Get API Key
 
 Get your API key from [console.anthropic.com](https://console.anthropic.com/)
 
-### 2. Add Environment Variable
+### 3. Add Environment Variable
 
 ```bash title=".env.local"
 ANTHROPIC_API_KEY=sk-ant-...
 ```
 
-### 3. Usage
+### 4. Usage
 
 ```ts
 import { generateText } from '@yourgpt/llm-sdk';
@@ -42,7 +48,7 @@ const result = await generateText({
 console.log(result.text);
 ```
 
-### 4. Streaming (API Route)
+### 5. Streaming (API Route)
 
 ```ts title="app/api/chat/route.ts"
 import { streamText } from '@yourgpt/llm-sdk';

--- a/apps/docs/content/docs/providers/google.mdx
+++ b/apps/docs/content/docs/providers/google.mdx
@@ -17,17 +17,27 @@ Google's Gemini models. Excellent for multimodal tasks with massive context wind
 
 ## Setup
 
-### 1. Get API Key
+### 1. Install Packages
+
+```bash
+npm install @yourgpt/copilot-sdk @yourgpt/llm-sdk openai
+```
+
+<Callout type="info">
+Google Gemini uses an OpenAI-compatible API, so we use the `openai` SDK.
+</Callout>
+
+### 2. Get API Key
 
 Get your API key from [Google AI Studio](https://aistudio.google.com/apikey)
 
-### 2. Add Environment Variable
+### 3. Add Environment Variable
 
 ```bash title=".env.local"
 GOOGLE_API_KEY=...
 ```
 
-### 3. Usage
+### 4. Usage
 
 ```ts
 import { generateText } from '@yourgpt/llm-sdk';
@@ -41,7 +51,7 @@ const result = await generateText({
 console.log(result.text);
 ```
 
-### 4. Streaming (API Route)
+### 5. Streaming (API Route)
 
 ```ts title="app/api/chat/route.ts"
 import { streamText } from '@yourgpt/llm-sdk';

--- a/apps/docs/content/docs/providers/index.mdx
+++ b/apps/docs/content/docs/providers/index.mdx
@@ -5,6 +5,7 @@ description: Connect to any LLM provider
 
 import { Cards, Card } from 'fumadocs-ui/components/card';
 import { Callout } from 'fumadocs-ui/components/callout';
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 
 Copilot SDK supports multiple LLM providers through `@yourgpt/llm-sdk`. **Switch providers without changing your frontend code.**
 
@@ -18,7 +19,25 @@ All providers use the same API. Change one line in your backend to switch from O
 
 ## How It Works
 
-Import providers from subpaths for optimal tree-shaking. Each provider returns a model instance that works with `generateText()` and `streamText()`.
+Install the SDK and the provider's official SDK. Each provider returns a model instance that works with `generateText()` and `streamText()`.
+
+### Installation
+
+<Tabs items={['OpenAI / Google / xAI', 'Anthropic']}>
+  <Tab value="OpenAI / Google / xAI">
+    ```bash
+    npm install @yourgpt/copilot-sdk @yourgpt/llm-sdk openai
+    ```
+    <Callout type="info">
+    OpenAI, Google Gemini, and xAI all use the `openai` SDK (OpenAI-compatible APIs).
+    </Callout>
+  </Tab>
+  <Tab value="Anthropic">
+    ```bash
+    npm install @yourgpt/copilot-sdk @yourgpt/llm-sdk @anthropic-ai/sdk
+    ```
+  </Tab>
+</Tabs>
 
 ### Backend Setup
 
@@ -76,7 +95,7 @@ const model = anthropic('claude-3-5-sonnet-20241022');
 import { google } from '@yourgpt/llm-sdk/google';
 const model = google('gemini-2.0-flash');
 
-// xAI
+// xAI (Grok)
 import { xai } from '@yourgpt/llm-sdk/xai';
 const model = xai('grok-3-fast-beta');
 
@@ -95,12 +114,27 @@ Your tools, UI, and all frontend code remain unchanged. The SDK normalizes respo
 
 ## Available Providers
 
-| Provider | Import | Example |
-|----------|--------|---------|
-| OpenAI | `@yourgpt/llm-sdk/openai` | `openai('gpt-4o')` |
-| Anthropic | `@yourgpt/llm-sdk/anthropic` | `anthropic('claude-3-5-sonnet-20241022')` |
-| Google | `@yourgpt/llm-sdk/google` | `google('gemini-2.0-flash')` |
-| xAI | `@yourgpt/llm-sdk/xai` | `xai('grok-3-fast-beta')` |
+| Provider | Import | SDK Required | Example |
+|----------|--------|--------------|---------|
+| OpenAI | `@yourgpt/llm-sdk/openai` | `openai` | `openai('gpt-4o')` |
+| Anthropic | `@yourgpt/llm-sdk/anthropic` | `@anthropic-ai/sdk` | `anthropic('claude-3-5-sonnet-20241022')` |
+| Google | `@yourgpt/llm-sdk/google` | `openai` | `google('gemini-2.0-flash')` |
+| xAI | `@yourgpt/llm-sdk/xai` | `openai` | `xai('grok-3-fast-beta')` |
+
+---
+
+## Why Only 2 SDKs?
+
+Most LLM providers now offer **OpenAI-compatible APIs**. This means you only need:
+
+| SDK | Providers |
+|-----|-----------|
+| `openai` | OpenAI, Google Gemini, xAI Grok, Azure OpenAI, Groq, Together AI, Ollama |
+| `@anthropic-ai/sdk` | Anthropic Claude (native SDK for full features) |
+
+<Callout type="info">
+Google and xAI use OpenAI-compatible endpoints. We automatically configure the correct `baseURL` for each provider.
+</Callout>
 
 ---
 

--- a/apps/docs/content/docs/providers/openai.mdx
+++ b/apps/docs/content/docs/providers/openai.mdx
@@ -18,17 +18,23 @@ The most popular LLM provider. Access GPT-4o, GPT-4 Turbo, and GPT-3.5 models.
 
 ## Setup
 
-### 1. Get API Key
+### 1. Install Packages
+
+```bash
+npm install @yourgpt/copilot-sdk @yourgpt/llm-sdk openai
+```
+
+### 2. Get API Key
 
 Get your API key from [platform.openai.com](https://platform.openai.com/api-keys)
 
-### 2. Add Environment Variable
+### 3. Add Environment Variable
 
 ```bash title=".env.local"
 OPENAI_API_KEY=sk-...
 ```
 
-### 3. Usage
+### 4. Usage
 
 ```ts
 import { generateText } from '@yourgpt/llm-sdk';
@@ -42,7 +48,7 @@ const result = await generateText({
 console.log(result.text);
 ```
 
-### 4. Streaming (API Route)
+### 5. Streaming (API Route)
 
 ```ts title="app/api/chat/route.ts"
 import { streamText } from '@yourgpt/llm-sdk';

--- a/apps/docs/content/docs/providers/xai.mdx
+++ b/apps/docs/content/docs/providers/xai.mdx
@@ -17,17 +17,27 @@ Cutting-edge AI from xAI. Grok models offer real-time information access and ult
 
 ## Setup
 
-### 1. Get API Key
+### 1. Install Packages
+
+```bash
+npm install @yourgpt/copilot-sdk @yourgpt/llm-sdk openai
+```
+
+<Callout type="info">
+xAI uses an OpenAI-compatible API, so we use the `openai` SDK.
+</Callout>
+
+### 2. Get API Key
 
 Get your API key from [console.x.ai](https://console.x.ai/)
 
-### 2. Add Environment Variable
+### 3. Add Environment Variable
 
 ```bash title=".env.local"
 XAI_API_KEY=xai-...
 ```
 
-### 3. Usage
+### 4. Usage
 
 ```ts
 import { generateText } from '@yourgpt/llm-sdk';
@@ -41,7 +51,7 @@ const result = await generateText({
 console.log(result.text);
 ```
 
-### 4. Streaming (API Route)
+### 5. Streaming (API Route)
 
 ```ts title="app/api/chat/route.ts"
 import { streamText } from '@yourgpt/llm-sdk';

--- a/apps/docs/content/docs/quickstart.mdx
+++ b/apps/docs/content/docs/quickstart.mdx
@@ -102,20 +102,24 @@ import { Steps, Step } from 'fumadocs-ui/components/steps';
     <Tabs items={['pnpm', 'npm', 'yarn']}>
       <Tab value="pnpm">
         ```bash
-        pnpm add @yourgpt/copilot-sdk @yourgpt/llm-sdk zod
+        pnpm add @yourgpt/copilot-sdk @yourgpt/llm-sdk openai zod
         ```
       </Tab>
       <Tab value="npm">
         ```bash
-        npm install @yourgpt/copilot-sdk @yourgpt/llm-sdk zod
+        npm install @yourgpt/copilot-sdk @yourgpt/llm-sdk openai zod
         ```
       </Tab>
       <Tab value="yarn">
         ```bash
-        yarn add @yourgpt/copilot-sdk @yourgpt/llm-sdk zod
+        yarn add @yourgpt/copilot-sdk @yourgpt/llm-sdk openai zod
         ```
       </Tab>
     </Tabs>
+
+    <Callout type="info">
+    The `openai` SDK works with OpenAI, Google Gemini, and xAI (all OpenAI-compatible). For Anthropic, install `@anthropic-ai/sdk` instead.
+    </Callout>
 
     ---
 

--- a/packages/copilot-sdk/package.json
+++ b/packages/copilot-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yourgpt/copilot-sdk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Build AI copilots with app context awareness",
   "type": "module",
   "exports": {

--- a/packages/llm-sdk/README.md
+++ b/packages/llm-sdk/README.md
@@ -5,7 +5,13 @@ Multi-provider LLM SDK with streaming. One API, any provider.
 ## Installation
 
 ```bash
-npm install @yourgpt/llm-sdk
+npm install @yourgpt/llm-sdk openai
+```
+
+For Anthropic, install `@anthropic-ai/sdk` instead:
+
+```bash
+npm install @yourgpt/llm-sdk @anthropic-ai/sdk
 ```
 
 ## Quick Start
@@ -18,7 +24,7 @@ export async function POST(req: Request) {
   const { messages } = await req.json();
 
   const result = await streamText({
-    model: openai("gpt-5"),
+    model: openai("gpt-4o"),
     system: "You are a helpful assistant.",
     messages,
   });
@@ -36,16 +42,16 @@ import { google } from "@yourgpt/llm-sdk/google";
 import { xai } from "@yourgpt/llm-sdk/xai";
 
 // OpenAI
-await streamText({ model: openai("gpt-5"), messages });
+await streamText({ model: openai("gpt-4o"), messages });
 
 // Anthropic
 await streamText({ model: anthropic("claude-sonnet-4-20250514"), messages });
 
-// Google
+// Google Gemini (uses OpenAI-compatible API)
 await streamText({ model: google("gemini-2.0-flash"), messages });
 
-// xAI
-await streamText({ model: xai("grok-3"), messages });
+// xAI Grok (uses OpenAI-compatible API)
+await streamText({ model: xai("grok-3-fast-beta"), messages });
 ```
 
 ## Server-Side Tools
@@ -56,7 +62,7 @@ import { openai } from "@yourgpt/llm-sdk/openai";
 import { z } from "zod";
 
 const result = await streamText({
-  model: openai("gpt-5"),
+  model: openai("gpt-4o"),
   messages,
   tools: {
     getWeather: tool({
@@ -77,14 +83,16 @@ return result.toDataStreamResponse();
 
 ## Supported Providers
 
-| Provider      | Import                       |
-| ------------- | ---------------------------- |
-| OpenAI        | `@yourgpt/llm-sdk/openai`    |
-| Anthropic     | `@yourgpt/llm-sdk/anthropic` |
-| Google Gemini | `@yourgpt/llm-sdk/google`    |
-| xAI (Grok)    | `@yourgpt/llm-sdk/xai`       |
-| Ollama        | `@yourgpt/llm-sdk/ollama`    |
-| Azure OpenAI  | `@yourgpt/llm-sdk/azure`     |
+| Provider      | Import                       | SDK Required        |
+| ------------- | ---------------------------- | ------------------- |
+| OpenAI        | `@yourgpt/llm-sdk/openai`    | `openai`            |
+| Anthropic     | `@yourgpt/llm-sdk/anthropic` | `@anthropic-ai/sdk` |
+| Google Gemini | `@yourgpt/llm-sdk/google`    | `openai`            |
+| xAI (Grok)    | `@yourgpt/llm-sdk/xai`       | `openai`            |
+| Ollama        | `@yourgpt/llm-sdk/ollama`    | `openai`            |
+| Azure OpenAI  | `@yourgpt/llm-sdk/azure`     | `openai`            |
+
+> **Note:** OpenAI, Google, xAI, Ollama, and Azure all use the `openai` SDK because they have OpenAI-compatible APIs. Only Anthropic requires its native SDK for full feature support.
 
 ## Documentation
 

--- a/packages/llm-sdk/package.json
+++ b/packages/llm-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yourgpt/llm-sdk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "LLM SDK for YourGPT - Multi-provider LLM integration",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -66,17 +66,13 @@
   },
   "peerDependencies": {
     "openai": "^4.0.0",
-    "@anthropic-ai/sdk": "^0.20.0",
-    "@google/generative-ai": "^0.21.0"
+    "@anthropic-ai/sdk": "^0.20.0"
   },
   "peerDependenciesMeta": {
     "openai": {
       "optional": true
     },
     "@anthropic-ai/sdk": {
-      "optional": true
-    },
-    "@google/generative-ai": {
       "optional": true
     }
   },

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -98,17 +98,15 @@ for pkg in "${PACKAGES[@]}"; do
 
   echo -e "  Publishing $PKG_NAME@$PKG_VERSION..."
 
-  cd "packages/$pkg"
-  npm publish --access public 2>&1 | grep -E "(notice|error|\+)"
+  # Use pnpm publish to handle workspace: protocol
+  pnpm --filter "@yourgpt/$pkg" publish --access public --no-git-checks 2>&1 | grep -E "(notice|error|\+|published)"
 
   if [ ${PIPESTATUS[0]} -eq 0 ]; then
     echo -e "${GREEN}  ✓ $PKG_NAME@$PKG_VERSION published${NC}"
   else
     echo -e "${RED}  ❌ Failed to publish $PKG_NAME${NC}"
-    cd ../..
     exit 1
   fi
-  cd ../..
 done
 
 echo ""


### PR DESCRIPTION
## Summary
- Google provider now uses OpenAI-compatible API (baseURL approach)
- Only 2 SDKs needed: `openai` (for OpenAI/Google/xAI) and `@anthropic-ai/sdk` (for Anthropic)
- Removed `@google/generative-ai` from peer dependencies
- **Version bumped to 0.2.0**

## Why This Change?
Most LLM providers now offer OpenAI-compatible APIs. This simplifies the SDK:

| SDK | Providers |
|-----|-----------|
| `openai` | OpenAI, Google Gemini, xAI Grok, Azure, Groq, Together AI, Ollama |
| `@anthropic-ai/sdk` | Anthropic Claude (native SDK for full features) |

## Changes
- Refactored Google provider to use OpenAI SDK with custom baseURL
- Added new Gemini models (2.5-pro, 2.5-flash, 2.0-flash-lite)
- Updated all documentation for hybrid SDK approach
- Added "Why Only 2 SDKs?" section to provider docs
- Updated publish script to use pnpm (handles workspace: protocol)

## Breaking Change
Google users need to change their dependency:
```bash
# Before
npm install @google/generative-ai

# After
npm install openai
```

Code remains unchanged - just the dependency.

## Test plan
- [x] Build passes for all packages
- [x] Documentation updated
- [x] Demo examples verified

🤖 Generated with [Claude Code](https://claude.ai/code)