### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/packages/copilot-sdk/package.json
+++ b/packages/copilot-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yourgpt/copilot-sdk",
-  "version": "0.2.0",
+  "version": "1.1.0",
   "description": "Build AI copilots with app context awareness",
   "type": "module",
   "exports": {

--- a/packages/llm-sdk/package.json
+++ b/packages/llm-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yourgpt/llm-sdk",
-  "version": "0.2.0",
+  "version": "1.1.0",
   "description": "LLM SDK for YourGPT - Multi-provider LLM integration",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Fixes version number - published packages are at 1.0.1, not 0.2.0.

🤖 Generated with [Claude Code](https://claude.ai/code)