### PR TITLE
chore: remove unused LLMConfig props

### DIFF
--- a/packages/copilot-sdk/src/core/index.ts
+++ b/packages/copilot-sdk/src/core/index.ts
@@ -86,7 +86,6 @@ export type {
   ToolCall,
   TokenUsage,
   // Config types
-  LLMProvider,
   LLMConfig,
   CloudConfig,
   Extension,
@@ -178,8 +177,6 @@ export {
   parseStreamEvent,
   serializeStreamEvent,
   formatSSE,
-  getDefaultModel,
-  DEFAULT_MODELS,
   // Tool functions
   tool,
   toolToOpenAIFormat,

--- a/packages/copilot-sdk/src/core/types/config.ts
+++ b/packages/copilot-sdk/src/core/types/config.ts
@@ -1,38 +1,14 @@
 /**
- * Supported LLM providers
- */
-export type LLMProvider =
-  | "openai"
-  | "anthropic"
-  | "google"
-  | "groq"
-  | "ollama"
-  | "custom";
-
-/**
- * LLM configuration
+ * LLM configuration (optional overrides sent to server)
+ *
+ * Note: The server uses its own configured model.
+ * These are optional hints that the server may use.
  */
 export interface LLMConfig {
-  /** LLM provider */
-  provider: LLMProvider;
-  /** Model name (e.g., 'gpt-4o', 'claude-3-5-sonnet-latest') */
-  model?: string;
-  /** API key for the provider */
-  apiKey?: string;
-  /** Base URL for custom/self-hosted models */
-  baseUrl?: string;
   /** Temperature (0-2) */
   temperature?: number;
   /** Maximum tokens in response */
   maxTokens?: number;
-  /** Top P sampling */
-  topP?: number;
-  /** Frequency penalty */
-  frequencyPenalty?: number;
-  /** Presence penalty */
-  presencePenalty?: number;
-  /** Enable streaming responses (default: true) */
-  streaming?: boolean;
 }
 
 /**
@@ -75,23 +51,4 @@ export interface CopilotConfig {
   extensions?: Extension[];
   /** Enable debug logging */
   debug?: boolean;
-}
-
-/**
- * Default LLM configurations per provider
- */
-export const DEFAULT_MODELS: Record<LLMProvider, string> = {
-  openai: "gpt-4o",
-  anthropic: "claude-3-5-sonnet-latest",
-  google: "gemini-pro",
-  groq: "llama-3.1-70b-versatile",
-  ollama: "llama3",
-  custom: "default",
-};
-
-/**
- * Get default model for a provider
- */
-export function getDefaultModel(provider: LLMProvider): string {
-  return DEFAULT_MODELS[provider] || "default";
 }

--- a/packages/copilot-sdk/src/react/hooks/useDevLogger.ts
+++ b/packages/copilot-sdk/src/react/hooks/useDevLogger.ts
@@ -40,8 +40,6 @@ export interface DevLoggerState {
     loaded: boolean;
   };
   config: {
-    provider: string;
-    model: string;
     runtimeUrl: string;
   };
 }
@@ -113,10 +111,6 @@ export function useDevLogger(): DevLoggerState {
         loaded: ctx.permissionsLoaded || false,
       },
       config: {
-        provider:
-          ctx.config?.config?.provider ||
-          (ctx.config?.cloud ? "yourgpt-cloud" : "unknown"),
-        model: ctx.config?.config?.model || "default",
         runtimeUrl: ctx.config?.runtimeUrl || ctx.config?.cloud?.endpoint || "",
       },
     };

--- a/packages/copilot-sdk/src/ui/components/ui/dev-logger.tsx
+++ b/packages/copilot-sdk/src/ui/components/ui/dev-logger.tsx
@@ -46,8 +46,6 @@ export interface DevLoggerState {
   };
   // Config
   config: {
-    provider: string;
-    model: string;
     runtimeUrl: string;
   };
 }
@@ -337,9 +335,7 @@ function AgentTab({ state }: { state: DevLoggerState }) {
 function ConfigTab({ state }: { state: DevLoggerState }) {
   return (
     <div className="space-y-4">
-      <Section title="Provider">
-        <Row label="Provider" value={state.config.provider || "Not set"} />
-        <Row label="Model" value={state.config.model || "Default"} />
+      <Section title="Runtime">
         <Row
           label="Runtime URL"
           value={state.config.runtimeUrl || "Not set"}


### PR DESCRIPTION
## Summary

The client-side `LLMConfig` was being sent to the server but **never used**. The server uses its own configured model.

Simplified `LLMConfig` to only include optional hints:

```typescript
// Before
export interface LLMConfig {
  provider: LLMProvider;  // Required but unused
  model?: string;
  apiKey?: string;
  // ... many more unused fields
}

// After
export interface LLMConfig {
  temperature?: number;
  maxTokens?: number;
}
```

## Removed
- `LLMProvider` type
- `provider`, `model`, `apiKey`, `baseUrl` fields
- `topP`, `frequencyPenalty`, `presencePenalty` fields  
- `streaming` field (already on CopilotProvider)
- `DEFAULT_MODELS` constant
- `getDefaultModel()` function
- Provider/Model from DevLogger UI

## Why
Users were getting TypeScript errors when using `config` prop without specifying `provider`, but the server ignores it anyway.

🤖 Generated with [Claude Code](https://claude.ai/code)