### PR TITLE
feat(llm-sdk): include usage directly in chat() result

### DIFF
--- a/apps/docs/content/docs/server.mdx
+++ b/apps/docs/content/docs/server.mdx
@@ -511,30 +511,32 @@ For a separate backend server:
 
     **Option 3: With `chat()` (Non-streaming)**
     ```ts
-    const result = await runtime.chat(body, {
-      onFinish: async ({ usage }) => {
-        if (usage) {
-          console.log('Tokens:', usage.totalTokens);
-        }
-      },
-    });
+    // Usage is included in result - strip before sending to client
+    const { usage, ...clientResult } = await runtime.chat(body);
+
+    if (usage) {
+      console.log('Tokens:', usage.total_tokens);
+      await billing.recordUsage(userId, usage.total_tokens);
+    }
+
+    res.json(clientResult); // Send without usage
     ```
 
-    **Option 4: Raw access (for server-side processing)**
+    **Option 4: Raw access with `collect()`**
     ```ts
     // Use { includeUsage: true } when you need usage in the result
     const { text, usage } = await runtime.stream(body).collect({ includeUsage: true });
-    console.log('Tokens:', usage?.totalTokens);
+    console.log('Tokens:', usage?.total_tokens);
     ```
 
     | Field | Type | Description |
     |-------|------|-------------|
-    | `usage.promptTokens` | `number` | Input tokens (prompt + context) |
-    | `usage.completionTokens` | `number` | Output tokens (response) |
-    | `usage.totalTokens` | `number` | Total tokens used |
+    | `usage.prompt_tokens` | `number` | Input tokens (prompt + context) |
+    | `usage.completion_tokens` | `number` | Output tokens (response) |
+    | `usage.total_tokens` | `number` | Total tokens used |
 
     <Callout type="info">
-    Usage is **stripped by default** from client-facing responses for security. Use `onFinish` callback to access usage server-side, or pass `{ includeUsage: true }` for raw API access.
+    For `chat()`, usage is **included in the result** - strip the `usage` key before sending to the Copilot client. For streaming, use `onFinish` callback or `{ includeUsage: true }` with `collect()`.
     </Callout>
   </Accordion>
 

--- a/examples/express-demo/package.json
+++ b/examples/express-demo/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@yourgpt/llm-sdk": "^1.5.2",
+    "@yourgpt/llm-sdk": "^1.5.3",
     "cors": "^2.8.5",
     "dotenv": "^16.4.0",
     "express": "^4.21.0",

--- a/examples/express-demo/src/index.ts
+++ b/examples/express-demo/src/index.ts
@@ -46,13 +46,21 @@ app.post("/api/copilot/stream", async (req, res) => {
 
 /**
  * Non-streaming - For Copilot SDK with streaming={false}
- * Returns: { text, messages, toolCalls }
+ * Returns: { text, messages, toolCalls } (usage stripped)
  */
 app.post("/api/copilot/chat", async (req, res) => {
   console.log("[/api/copilot/chat] Non-streaming JSON");
-  const result = await runtime.chat(req.body);
-  console.log("[/api/copilot/chat] Result:", result);
-  res.json(result);
+
+  // Usage is now included in result - strip before sending to client
+  const { usage, ...clientResult } = await runtime.chat(req.body);
+
+  // Log usage server-side for billing
+  if (usage) {
+    console.log("[/api/copilot/chat] Usage:", usage);
+  }
+
+  // Send to client without usage
+  res.json(clientResult);
 });
 
 /**

--- a/packages/llm-sdk/package.json
+++ b/packages/llm-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yourgpt/llm-sdk",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "LLM SDK for YourGPT - Multi-provider LLM integration",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/llm-sdk/src/server/generate-result.ts
+++ b/packages/llm-sdk/src/server/generate-result.ts
@@ -17,7 +17,7 @@
  * ```
  */
 
-import type { DoneEventMessage } from "@yourgpt/copilot-sdk/core";
+import type { DoneEventMessage } from "../core/stream-events";
 
 export interface GenerateResultData {
   text: string;


### PR DESCRIPTION
## Summary
- `chat()` now returns usage directly in result
- User strips `usage` key before sending to Copilot client
- Removed `onFinish` callback from `chat()` (not needed - usage is in result)

## Usage
```ts
// Usage is included in result - strip before sending to client
const { usage, ...clientResult } = await runtime.chat(body);

if (usage) {
  await billing.recordUsage(userId, usage.total_tokens);
}

res.json(clientResult); // Send without usage
```

## Breaking Change
`chat()` no longer accepts `onFinish` callback. Use destructuring to access usage.

## Test plan
- [ ] Test `chat()` returns usage in result
- [ ] Test stripping usage before sending to client
- [ ] Verify docs are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)