### PR TITLE
feat(tools): add `hidden` property to hide tools from chat UI

### DIFF
--- a/apps/docs/content/docs/tools/frontend-tools.mdx
+++ b/apps/docs/content/docs/tools/frontend-tools.mdx
@@ -54,6 +54,7 @@ function MyTools() {
 | `parameters` | Yes | Zod schema for inputs |
 | `handler` | Yes | Async function that runs |
 | `requiresApproval` | No | Ask user before running |
+| `hidden` | No | Hide tool from chat UI (still executes) |
 
 ---
 
@@ -112,6 +113,43 @@ useTools({
 
 <Callout type="warning">
 Use `requiresApproval: true` for destructive or sensitive actions.
+</Callout>
+
+---
+
+## Hidden Tools
+
+Hide tool execution from the chat UI while still executing normally:
+
+```tsx
+useTools({
+  navigate: {
+    description: 'Navigate to a page in the app',
+    parameters: z.object({ path: z.string() }),
+    hidden: true, // Won't show in chat UI
+    handler: async ({ path }) => {
+      router.push(path);
+      return { navigated: path };
+    },
+  },
+
+  track_event: {
+    description: 'Track analytics event',
+    parameters: z.object({
+      event: z.string(),
+      properties: z.record(z.any()).optional(),
+    }),
+    hidden: true, // Silent background operation
+    handler: async ({ event, properties }) => {
+      analytics.track(event, properties);
+      return { tracked: true };
+    },
+  },
+});
+```
+
+<Callout type="info">
+Hidden tools are useful for navigation, analytics, or background operations that shouldn't clutter the chat UI.
 </Callout>
 
 ---

--- a/examples/playground/components/playground/DashboardTools.tsx
+++ b/examples/playground/components/playground/DashboardTools.tsx
@@ -368,6 +368,45 @@ function CartTool({
 }
 
 // ===========================================
+// Hidden Tool Example
+// ===========================================
+
+/**
+ * Example of a hidden tool that executes but doesn't show in the UI.
+ * Useful for navigation, analytics, or background operations.
+ */
+function NavigationTool() {
+  useTool({
+    name: "navigate",
+    description:
+      "Navigate to a page section on the dashboard. Use this to help users find features.",
+    hidden: true, // This tool won't show in the chat UI
+    inputSchema: {
+      type: "object",
+      properties: {
+        section: {
+          type: "string",
+          enum: ["counter", "cart", "settings", "tools"],
+          description: "The dashboard section to navigate to",
+        },
+      },
+      required: ["section"],
+    },
+    handler: async ({ section }: { section: string }) => {
+      // In a real app, this would scroll to or highlight the section
+      console.log(`[Hidden Tool] Navigating to: ${section}`);
+      return {
+        success: true,
+        section,
+        message: `Navigated to ${section} section`,
+      };
+    },
+  });
+
+  return null;
+}
+
+// ===========================================
 // Built-in Tools Components
 // ===========================================
 
@@ -535,6 +574,9 @@ export function DashboardTools({
       {toolsEnabled.updateCart && (
         <CartTool dashboardState={dashboardState} actions={actions} />
       )}
+
+      {/* Hidden tool example - always enabled but invisible in UI */}
+      <NavigationTool />
 
       {/* Built-in tools - screenshot and console logs */}
       {toolsEnabled.captureScreenshot && <ScreenshotTool />}

--- a/packages/copilot-sdk/src/core/types/tools.ts
+++ b/packages/copilot-sdk/src/core/types/tools.ts
@@ -406,6 +406,14 @@ export interface ToolDefinition<TParams = Record<string, unknown>> {
   available?: boolean;
 
   /**
+   * Hide this tool's execution from the chat UI.
+   * When true, tool calls and results won't be displayed to the user,
+   * but the tool will still execute normally.
+   * @default false
+   */
+  hidden?: boolean;
+
+  /**
    * Require user approval before execution.
    * Can be:
    * - `true`: Always require approval
@@ -712,6 +720,8 @@ export interface ToolConfig<TParams = Record<string, unknown>> {
   render?: (props: ToolRenderProps<TParams>) => unknown;
   /** Whether the tool is available */
   available?: boolean;
+  /** Hide this tool from chat UI display */
+  hidden?: boolean;
   /** Require user approval before execution */
   needsApproval?: boolean | ((params: TParams) => boolean | Promise<boolean>);
   /** Custom message shown in the approval UI */
@@ -764,6 +774,7 @@ export function tool<TParams = Record<string, unknown>>(
     handler: config.handler,
     render: config.render,
     available: config.available,
+    hidden: config.hidden,
     needsApproval: config.needsApproval,
     approvalMessage: config.approvalMessage,
     aiResponseMode: config.aiResponseMode,

--- a/packages/copilot-sdk/src/ui/components/composed/chat/default-message.tsx
+++ b/packages/copilot-sdk/src/ui/components/composed/chat/default-message.tsx
@@ -271,12 +271,18 @@ export function DefaultMessage({
     );
   }
 
-  // Separate tool executions into categories
+  // Helper: check if a tool is hidden (shouldn't appear in UI)
+  const isToolHidden = (toolName: string): boolean => {
+    const toolDef = registeredTools?.find((t) => t.name === toolName);
+    return toolDef?.hidden === true;
+  };
+
+  // Separate tool executions into categories (excluding hidden tools)
   const pendingApprovalTools = message.toolExecutions?.filter(
-    (exec) => exec.approvalStatus === "required",
+    (exec) => exec.approvalStatus === "required" && !isToolHidden(exec.name),
   );
   const completedTools = message.toolExecutions?.filter(
-    (exec) => exec.approvalStatus !== "required",
+    (exec) => exec.approvalStatus !== "required" && !isToolHidden(exec.name),
   );
 
   // Helper: check if tool has any custom render (toolRenderers or tool.render)
@@ -440,18 +446,20 @@ export function DefaultMessage({
               </div>
             )}
 
-            {/* MCP-UI Resources - Interactive components from MCP tools */}
-            {message.toolExecutions?.map((exec) => {
-              const uiResources = exec.result?._uiResources;
-              if (!uiResources || uiResources.length === 0) return null;
-              return (
-                <MCPUIFrameList
-                  key={`${exec.id}-ui`}
-                  resources={uiResources}
-                  className="mt-2"
-                />
-              );
-            })}
+            {/* MCP-UI Resources - Interactive components from MCP tools (excluding hidden) */}
+            {message.toolExecutions
+              ?.filter((exec) => !isToolHidden(exec.name))
+              .map((exec) => {
+                const uiResources = exec.result?._uiResources;
+                if (!uiResources || uiResources.length === 0) return null;
+                return (
+                  <MCPUIFrameList
+                    key={`${exec.id}-ui`}
+                    resources={uiResources}
+                    className="mt-2"
+                  />
+                );
+              })}
 
             {/* Tool Approval Confirmations - Priority: toolRenderers > tool.render > default */}
             {pendingApprovalTools && pendingApprovalTools.length > 0 && (

--- a/packages/llm-sdk/src/core/tool.ts
+++ b/packages/llm-sdk/src/core/tool.ts
@@ -37,6 +37,14 @@ export interface ToolConfig<TParams extends z.ZodType, TResult = unknown> {
 
   /** Function to execute when the tool is called */
   execute: (params: z.infer<TParams>, context: ToolContext) => Promise<TResult>;
+
+  /**
+   * Hide this tool's execution from the chat UI.
+   * When true, tool calls and results won't be displayed to the user,
+   * but the tool will still execute normally.
+   * @default false
+   */
+  hidden?: boolean;
 }
 
 /**
@@ -72,6 +80,7 @@ export function tool<TParams extends z.ZodType, TResult = unknown>(
     description: config.description,
     parameters: config.parameters,
     execute: config.execute,
+    hidden: config.hidden,
   };
 }
 

--- a/packages/llm-sdk/src/core/types.ts
+++ b/packages/llm-sdk/src/core/types.ts
@@ -148,6 +148,13 @@ export interface Tool<TParams = unknown, TResult = unknown> {
   parameters: z.ZodType<TParams>;
   /** Execute function */
   execute: (params: TParams, context: ToolContext) => Promise<TResult>;
+  /**
+   * Hide this tool's execution from the chat UI.
+   * When true, tool calls and results won't be displayed to the user,
+   * but the tool will still execute normally.
+   * @default false
+   */
+  hidden?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add optional `hidden?: boolean` property to tool definitions
- Hidden tools execute normally but don't appear in the chat UI
- Useful for navigation, analytics, or background operations

## Changes
- **copilot-sdk**: Added `hidden` to `ToolDefinition` and `ToolConfig` interfaces
- **llm-sdk**: Added `hidden` to `Tool` and `ToolConfig` interfaces  
- **UI**: Filter hidden tools in `default-message.tsx`
- **Playground**: Added `NavigationTool` example
- **Docs**: Documented `hidden` property in frontend-tools.mdx

## Usage
```tsx
useTools({
  navigate: {
    hidden: true,  // Won't show in UI
    description: 'Navigate to a page',
    parameters: z.object({ path: z.string() }),
    handler: async ({ path }) => {
      router.push(path);
      return { success: true };
    }
  }
});
```

## Test plan
- [ ] Build passes (`pnpm build`)
- [ ] Hidden tools don't appear in chat UI
- [ ] Hidden tools still execute normally
- [ ] Non-hidden tools display correctly

Closes #56, #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)