### PR TITLE
feat: add hidden property to tool definitions for UI visibility control

### DIFF
--- a/.changeset/add-hidden-tool.md
+++ b/.changeset/add-hidden-tool.md
@@ -1,0 +1,5 @@
+---
+"@yourgpt/copilot-sdk": patch
+---
+
+Add hidden property to tool definitions for UI visibility control.

--- a/packages/copilot-sdk/src/core/types/tools.ts
+++ b/packages/copilot-sdk/src/core/types/tools.ts
@@ -356,6 +356,18 @@ export interface ToolDefinition<TParams = Record<string, unknown>> {
    * ```
    */
   completedTitle?: string | ((args: TParams) => string);
+
+  /**
+   * Whether this tool's execution messages should be hidden in the default chat UI.
+   *
+   * If `true`, the tool still executes normally, but its execution messages are not shown
+   * in the default chat UI.
+   *
+   * This does NOT disable the tool.
+   *
+   * Default behavior is visible (`undefined` or `false`).
+   */
+  hidden?: boolean;
   /** JSON Schema for input parameters */
   inputSchema: ToolInputSchema;
   /** Handler function (optional for client tools registered on server) */
@@ -664,6 +676,9 @@ export interface ToolConfig<TParams = Record<string, unknown>> {
   /** Title shown after completion */
   completedTitle?: string | ((args: TParams) => string);
 
+  /** Whether this tool's execution messages should be hidden in the default chat UI */
+  hidden?: boolean;
+
   /** JSON Schema for input parameters */
   inputSchema?: ToolInputSchema;
   /** Handler function */
@@ -718,6 +733,7 @@ export function tool<TParams = Record<string, unknown>>(
     title: config.title,
     executingTitle: config.executingTitle,
     completedTitle: config.completedTitle,
+    hidden: config.hidden,
     // Schema and handlers
     inputSchema: config.inputSchema ?? {
       type: "object",

--- a/packages/copilot-sdk/src/ui/components/composed/chat/default-message.tsx
+++ b/packages/copilot-sdk/src/ui/components/composed/chat/default-message.tsx
@@ -158,12 +158,18 @@ export function DefaultMessage({
     );
   }
 
+  // Helper: check whether a tool should be hidden in the default UI
+  const isToolHidden = (toolName: string): boolean => {
+    const toolDef = registeredTools?.find((t) => t.name === toolName);
+    return toolDef?.hidden === true;
+  };
+
   // Separate tool executions into categories
   const pendingApprovalTools = message.toolExecutions?.filter(
-    (exec) => exec.approvalStatus === "required",
+    (exec) => exec.approvalStatus === "required" && !isToolHidden(exec.name),
   );
   const completedTools = message.toolExecutions?.filter(
-    (exec) => exec.approvalStatus !== "required",
+    (exec) => exec.approvalStatus !== "required" && !isToolHidden(exec.name),
   );
 
   // Helper: check if tool has any custom render (toolRenderers or tool.render)

--- a/packages/copilot-sdk/tests/default-message.test.tsx
+++ b/packages/copilot-sdk/tests/default-message.test.tsx
@@ -1,0 +1,111 @@
+import * as React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { DefaultMessage } from "../src/ui/components/composed/chat/default-message";
+import type { ChatMessage } from "../src/ui/components/composed/chat/types";
+import type { ToolDefinition } from "../src/core/types/tools";
+
+// Mock ToolSteps to isolate UI filtering behavior
+vi.mock("../src/ui/components/ui/tool-steps", () => ({
+  ToolSteps: ({ steps }: { steps: Array<{ name: string }> }) => (
+    <div data-testid="tool-steps">
+      {steps.map((step) => step.name).join(",")}
+    </div>
+  ),
+}));
+
+// Minimal ToolDefinition mock (future-proofed)
+const makeTool = (name: string, hidden?: boolean) =>
+  ({
+    name,
+    description: `${name} tool`,
+    location: "client",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+    hidden,
+  }) as ToolDefinition;
+
+// Minimal assistant message with one completed tool execution
+const makeAssistantMessage = (toolName: string): ChatMessage =>
+  ({
+    id: "msg-1",
+    role: "assistant",
+    content: "Assistant response",
+    toolExecutions: [
+      {
+        id: "exec-1",
+        name: toolName,
+        args: {},
+        status: "completed",
+        timestamp: Date.now(),
+        approvalStatus: "none",
+        result: {
+          success: true,
+        },
+      } as any, // keep test resilient to internal type changes
+    ],
+  }) as ChatMessage;
+
+describe("DefaultMessage - hidden tool visibility", () => {
+  it("renders tool execution when hidden is false", () => {
+    render(
+      <DefaultMessage
+        message={makeAssistantMessage("visible_tool")}
+        userAvatar={{}}
+        assistantAvatar={{}}
+        registeredTools={[makeTool("visible_tool", false)]}
+      />,
+    );
+
+    expect(screen.getByText("Assistant response")).toBeInTheDocument();
+    expect(screen.getByTestId("tool-steps")).toHaveTextContent("visible_tool");
+  });
+
+  it("renders tool execution when hidden is undefined (default visible behavior)", () => {
+    render(
+      <DefaultMessage
+        message={makeAssistantMessage("default_visible_tool")}
+        userAvatar={{}}
+        assistantAvatar={{}}
+        registeredTools={[makeTool("default_visible_tool")]}
+      />,
+    );
+
+    expect(screen.getByTestId("tool-steps")).toHaveTextContent(
+      "default_visible_tool",
+    );
+  });
+
+  it("does not render tool execution when hidden=true", () => {
+    render(
+      <DefaultMessage
+        message={makeAssistantMessage("hidden_tool")}
+        userAvatar={{}}
+        assistantAvatar={{}}
+        registeredTools={[makeTool("hidden_tool", true)]}
+      />,
+    );
+
+    expect(screen.getByText("Assistant response")).toBeInTheDocument();
+    expect(screen.queryByTestId("tool-steps")).not.toBeInTheDocument();
+    expect(screen.queryByText("hidden_tool")).not.toBeInTheDocument();
+  });
+
+  it("renders tool execution if registeredTools is undefined (no filtering applied)", () => {
+    render(
+      <DefaultMessage
+        message={makeAssistantMessage("no_registry_tool")}
+        userAvatar={{}}
+        assistantAvatar={{}}
+      />,
+    );
+
+    expect(screen.getByTestId("tool-steps")).toHaveTextContent(
+      "no_registry_tool",
+    );
+  });
+});


### PR DESCRIPTION
Closes #56

## Description

This PR introduces a per-tool `hidden` property that allows developers to hide specific tool execution messages from the default chat UI while keeping tool execution and AI behavior unchanged.

Instead of relying on global string-matching or navigation-specific logic, this provides an explicit and scalable configuration at the tool definition level.

When `hidden: true` is set on a tool:
- The tool executes normally
- The agent loop remains unaffected
- The tool execution UI is suppressed in the default chat UI

---

## Changes

- Added `hidden?: boolean` to `ToolDefinition`
- Added `hidden?: boolean` to `ToolConfig`
- Updated `tool()` helper to pass through the `hidden` property
- Updated `DefaultMessage` to filter out hidden tools from UI rendering
- Added unit tests to verify:
  - Non-hidden tools render normally
  - Default (undefined) behavior remains visible
  - Hidden tools are not rendered in the default UI
  - Behavior when `registeredTools` is undefined

---

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

---

## Testing

- [x] I've tested this locally
- [x] I've added/updated tests
- [ ] All existing tests pass

(Note: Test infrastructure is present, and added tests cover hidden tool visibility behavior.)

---

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I've updated the documentation (if needed)
- [x] I've added tests that prove my fix/feature works
- [x] New and existing tests pass locally

---

## Screenshots (if applicable)

N/A – UI behavior change is covered via unit tests.