### PR TITLE
fix(mcp): handle type: resource with ui:// URIs for MCP-UI rendering

### DIFF
--- a/packages/copilot-sdk/src/mcp/tools/MCPToolAdapter.ts
+++ b/packages/copilot-sdk/src/mcp/tools/MCPToolAdapter.ts
@@ -12,6 +12,7 @@ import type {
   MCPTextContent,
   MCPImageContent,
   MCPUIContent,
+  MCPResourceContent,
 } from "../types";
 import type { MCPUIResource } from "../ui/types";
 import type {
@@ -234,15 +235,30 @@ export class MCPToolAdapter {
           break;
         }
 
-        case "resource":
+        case "resource": {
           // Handle embedded resource content
-          if ("text" in content.resource && content.resource.text) {
-            textParts.push(content.resource.text);
+          // Check if this is a UI resource (uri starts with ui://)
+          // MCP servers return type: "resource" with ui:// URIs per MCP spec
+          const res = (content as MCPResourceContent).resource;
+          if (res.uri?.startsWith("ui://")) {
+            // This is a UI resource - extract for rendering
+            uiResources.push({
+              uri: res.uri,
+              mimeType:
+                (res.mimeType as MCPUIContent["resource"]["mimeType"]) ||
+                "text/html",
+              content: res.text, // MCP uses "text" field, normalize to "content"
+              blob: res.blob,
+            });
+          } else if (res.text) {
+            // Regular resource with text content
+            textParts.push(res.text);
           }
           break;
+        }
 
         case "ui": {
-          // Handle MCP-UI content
+          // Handle MCP-UI content (non-standard but supported for compatibility)
           const uiContent = content as MCPUIContent;
           uiResources.push({
             uri: uiContent.resource.uri,


### PR DESCRIPTION
## Summary
Fix MCP-UI rendering for resources from real MCP servers (Shopify, Canva, etc.)

## Problem
MCP servers return `type: "resource"` with `ui://` URIs per the MCP spec, but the SDK only looked for `type: "ui"` which doesn't exist in the spec.

| What | SDK Expected | MCP Servers Return |
|------|--------------|-------------------|
| Type | `type: "ui"` | `type: "resource"` with `ui://` URI |
| Content | `content` field | `text` field |

This caused MCP-UI components to not render - they were silently ignored.

## Changes
- Check if resource URI starts with `ui://` and treat as UI resource
- Accept `text` field (MCP spec) in addition to `content` field  
- Keep `type: "ui"` handling for backwards compatibility

## Test plan
- [ ] Build passes
- [ ] MCP-UI resources from Shopify/Canva MCP servers render correctly
- [ ] Existing `type: "ui"` resources still work

Fixes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)