### PR TITLE
feat(copilot-sdk): expose wasStopped flag in CopilotContext

### DIFF
--- a/packages/copilot-sdk/src/react/provider/CopilotProvider.tsx
+++ b/packages/copilot-sdk/src/react/provider/CopilotProvider.tsx
@@ -409,6 +409,8 @@ export interface CopilotContextValue {
   status: "ready" | "submitted" | "streaming" | "error";
   error: Error | null;
   isLoading: boolean;
+  /** True from when stop() is called until the next sendMessage(). */
+  wasStopped: boolean;
 
   // Chat actions
   sendMessage: (
@@ -950,12 +952,16 @@ export function CopilotProvider(props: CopilotProviderProps) {
     async (content: string, attachments?: MessageAttachment[]) => {
       debugLog("Sending message:", content);
       setAgentIteration(0); // reset before each new user message
+      setWasStopped(false); // reset for new run
       await chatRef.current?.sendMessage(content, attachments);
     },
     [debugLog],
   );
 
+  const [wasStopped, setWasStopped] = useState(false);
+
   const stop = useCallback(() => {
+    setWasStopped(true);
     chatRef.current?.stop();
   }, []);
 
@@ -1055,6 +1061,7 @@ export function CopilotProvider(props: CopilotProviderProps) {
       status,
       error,
       isLoading,
+      wasStopped,
 
       // Chat actions
       sendMessage,
@@ -1114,6 +1121,7 @@ export function CopilotProvider(props: CopilotProviderProps) {
       status,
       error,
       isLoading,
+      wasStopped,
       sendMessage,
       stop,
       clearMessages,


### PR DESCRIPTION
Adds a `wasStopped` boolean to `CopilotContextValue` that is set to true when `stop()` is called and reset to false on the next `sendMessage()`, allowing consumers to distinguish a user-initiated stop from other non-streaming states.

## Description

<!-- What does this PR do? Link to related issue if applicable -->

Exposes a `wasStopped` flag through `CopilotContext` so consumers can tell whether the current idle state was caused by a user-initiated stop vs. never having started or finishing naturally. This is useful for conditionally rendering UI like a "Generation was stopped" notice.

Fixes #

## Changes

<!-- List the main changes in this PR -->

- Added `wasStopped: boolean` to the `CopilotContextValue` interface
- Added `wasStopped` state in `CopilotProvider`, set to `true` inside `stop()` and reset to `false` at the start of `sendMessage()`
- Exposed `wasStopped` in both context value memo objects

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

<!-- How has this been tested? -->

- [x] I've tested this locally
- [ ] I've added/updated tests
- [ ] All existing tests pass

## Checklist

<!-- Check all that apply -->

- [x] My code follows the project's style guidelines
- [ ] I've updated the documentation (if needed)
- [ ] I've added tests that prove my fix/feature works
- [ ] New and existing tests pass locally

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

N/A
