### PR TITLE
fix(chat): scope copy button to message content bubble only

### DIFF
--- a/packages/copilot-sdk/src/ui/components/composed/chat/default-message.tsx
+++ b/packages/copilot-sdk/src/ui/components/composed/chat/default-message.tsx
@@ -36,12 +36,15 @@ function FloatingActions({
   align = "left",
   onEdit,
   className,
+  copyContent,
 }: {
   message: ChatMessage;
   role: "user" | "assistant";
   align?: "left" | "right";
   onEdit?: () => void;
   className?: string;
+  /** Text to copy. When provided, copy button uses this instead of message.content. When explicitly null, copy button is hidden. */
+  copyContent?: string | null;
 }) {
   const ctx = useMessageActionsContext();
   const [copiedId, setCopiedId] = React.useState<string | null>(null);
@@ -64,6 +67,10 @@ function FloatingActions({
           typeof action.hidden === "function"
             ? action.hidden({ message })
             : action.hidden;
+        // Hide copy button when there is no displayable text content
+        if (action.id === "copy" && copyContent != null && !copyContent.trim())
+          return null;
+        if (action.id === "copy" && copyContent === null) return null;
         if (isHidden) return null;
 
         const isCopied = copiedId === action.id;
@@ -88,7 +95,11 @@ function FloatingActions({
                 return;
               }
               if (action.id === "copy") {
-                navigator.clipboard.writeText(message.content ?? "");
+                const text =
+                  copyContent !== undefined
+                    ? (copyContent ?? "")
+                    : (message.content ?? "");
+                navigator.clipboard.writeText(text);
                 setCopiedId("copy");
                 setTimeout(() => setCopiedId(null), 1500);
                 return;
@@ -671,16 +682,26 @@ export function DefaultMessage({
           <div className="relative">
             {/* Message Content - show FIRST (AI's words before tool calls) */}
             {cleanContent?.trim() && (
-              <MessageContent
-                className={cn(
-                  "csdk-message-assistant rounded-lg px-4 py-2 bg-muted",
-                  assistantMessageClassName,
-                )}
-                markdown
-                size={size}
-              >
-                {cleanContent}
-              </MessageContent>
+              <div className="relative">
+                <MessageContent
+                  className={cn(
+                    "csdk-message-assistant rounded-lg px-4 py-2 bg-muted",
+                    assistantMessageClassName,
+                  )}
+                  markdown
+                  size={size}
+                >
+                  {cleanContent}
+                </MessageContent>
+                {/* Copy button — positioned inside the content bubble */}
+                <FloatingActions
+                  message={message}
+                  role="assistant"
+                  align="right"
+                  className="absolute bottom-1 right-1"
+                  copyContent={cleanContent}
+                />
+              </div>
             )}
 
             {/* Custom Tool Renderers - Priority: tool.render > fallbackToolRenderer > toolRenderers */}
@@ -934,14 +955,6 @@ export function DefaultMessage({
                 buttonClassName={followUpButtonClassName}
               />
             )}
-
-            {/* Floating actions for assistant messages */}
-            <FloatingActions
-              message={message}
-              role="assistant"
-              align="right"
-              className="absolute bottom-1 right-1"
-            />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Description

Fixes the copy button appearing on all assistant message types. It now only appears on messages with text content, positioned inside the content bubble, and copies exactly the displayed text.

## Changes

- Moved `FloatingActions` (copy button) inside a `relative` wrapper around `MessageContent` so it is scoped to the text bubble
- Copy button no longer renders on messages that have only tool executions (no text content)
- Copy action now uses `cleanContent` (follow-up questions and "Sources:" lines stripped) instead of raw `message.content`, matching what is actually visible
- Added `copyContent` prop to `FloatingActions` to control copied text and button visibility

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] I've tested this locally

**Manual test cases:**
- Text-only assistant message → copy button appears on hover inside the bubble, copies correctly
- Message with only tool calls (no text) → copy button does not appear
- Message with both text and tool calls → copy button appears on the text bubble only
- Copied text does not include follow-up question markers or "Sources:" lines

## Checklist

- [x] My code follows the project's style guidelines
- [x] New and existing tests pass locally

