### PR TITLE
feat(llm-sdk): MCP servers + reasoning effort + runtime.response() (supersedes #98)

### DIFF
--- a/apps/docs/content/docs/llm-sdk/generate-text.mdx
+++ b/apps/docs/content/docs/llm-sdk/generate-text.mdx
@@ -52,11 +52,24 @@ const result = await generateText({
       strict: true,
     },
   },
+
+  // Optional: Remote MCP servers (OpenAI Responses + Anthropic native)
+  mcpServers: [
+    {
+      label: 'github',
+      url: 'https://mcp.github.com/sse',
+      headers: { Authorization: `Bearer ${token}` },
+      allowedTools: ['create_issue'],
+    },
+  ],
+
+  // Optional: Reasoning / thinking effort (provider-translated)
+  reasoningEffort: 'medium',  // 'minimal' | 'low' | 'medium' | 'high' | { budgetTokens } | { raw }
 });
 ```
 
 <Callout>
-  `responseFormat` works across OpenAI, Anthropic, Google, Azure, xAI, Together, Fireworks, OpenRouter, and Ollama — each adapter translates to the provider's native field. See [Structured Output](/docs/llm-sdk/structured-output) for per-provider details and gotchas.
+  `responseFormat`, `mcpServers`, and `reasoningEffort` work across providers via per-adapter translation — see [Structured Output](/docs/llm-sdk/structured-output) for the per-provider mapping tables and gotchas, and [runtime.response()](/docs/llm-sdk/response) for a one-shot convenience wrapper.
 </Callout>
 
 ---

--- a/apps/docs/content/docs/llm-sdk/meta.json
+++ b/apps/docs/content/docs/llm-sdk/meta.json
@@ -1,5 +1,11 @@
 {
   "title": "LLM SDK",
   "icon": "AiChip1",
-  "pages": ["generate-text", "stream-text", "structured-output", "tools"]
+  "pages": [
+    "generate-text",
+    "stream-text",
+    "structured-output",
+    "response",
+    "tools"
+  ]
 }

--- a/apps/docs/content/docs/llm-sdk/response.mdx
+++ b/apps/docs/content/docs/llm-sdk/response.mdx
@@ -89,6 +89,11 @@ const data = JSON.parse(result.text);
     name: string;
     args: Record<string, unknown>;
   }>;
+  usage?: {            // present when the provider emitted usage on `done`
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
 }
 ```
 

--- a/apps/docs/content/docs/llm-sdk/response.mdx
+++ b/apps/docs/content/docs/llm-sdk/response.mdx
@@ -1,0 +1,195 @@
+---
+title: runtime.response()
+description: One-shot prompt-in / JSON-out call with MCP servers, reasoning effort, and structured output
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+`runtime.response()` is an ergonomic wrapper for the common "give me one
+answer back" case — a single prompt, optional MCP servers, optional
+reasoning effort, optional JSON schema, one response. No streaming, no
+multi-step agent loop.
+
+It's a thin convenience over `runtime.generate()`: same adapter chain,
+same per-provider translation, same fallback behavior. Use it when you
+don't need streaming or tool-call introspection.
+
+```ts
+import { createRuntime, createFallbackChain } from '@yourgpt/llm-sdk';
+import { createOpenAI } from '@yourgpt/llm-sdk/openai';
+import { createAnthropic } from '@yourgpt/llm-sdk/anthropic';
+
+const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const anthropic = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+const runtime = createRuntime({
+  adapter: createFallbackChain({
+    models: [
+      openai.languageModel('gpt-4o'),
+      anthropic.languageModel('claude-opus-4-7'),
+    ],
+    strategy: 'priority',
+  }),
+});
+
+const result = await runtime.response({
+  prompt: 'Extract the top 3 fastest land animals as JSON.',
+  reasoningEffort: 'medium',
+  responseFormat: {
+    type: 'json_schema',
+    json_schema: {
+      name: 'animals',
+      schema: {
+        type: 'object',
+        properties: {
+          animals: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                top_speed_kmh: { type: 'number' },
+              },
+              required: ['name', 'top_speed_kmh'],
+            },
+          },
+        },
+        required: ['animals'],
+      },
+      strict: true,
+    },
+  },
+});
+
+const data = JSON.parse(result.text);
+// → { animals: [{ name: 'Cheetah', top_speed_kmh: 120 }, ...] }
+```
+
+---
+
+## Parameters
+
+| Param | Type | Description |
+|---|---|---|
+| `prompt` | `string` | The user message. Sent as a single `role: 'user'` turn. |
+| `systemPrompt` | `string?` | Optional system prompt (overrides any default on the runtime). |
+| `mcpServers` | `McpServerConfig[]?` | Remote MCP servers the model can call. See [Structured Output → MCP servers](/docs/llm-sdk/structured-output#mcp-servers). |
+| `reasoningEffort` | `ReasoningEffort?` | `'minimal'`/`'low'`/`'medium'`/`'high'` or `{ budgetTokens }` or `{ raw }`. See [Structured Output → Reasoning effort](/docs/llm-sdk/structured-output#reasoning-effort). |
+| `responseFormat` | `ResponseFormat?` | JSON-schema constraint. See [Structured Output](/docs/llm-sdk/structured-output). |
+| `maxTokens` | `number?` | Maximum tokens for the completion. |
+| `temperature` | `number?` | Sampling temperature (0–2). Silently dropped on OpenAI reasoning models. |
+
+## Result
+
+```ts
+{
+  text: string;        // model output (parse yourself if responseFormat used)
+  toolCalls: Array<{   // function-tool calls; MCP tool calls are resolved provider-side
+    id: string;
+    name: string;
+    args: Record<string, unknown>;
+  }>;
+}
+```
+
+The method **throws** if the underlying call errors out. Catch at the
+call site or rely on the fallback chain to route past failures.
+
+---
+
+## When to use `response()` vs `generate()` / `chat()`
+
+| Use case | Method |
+|---|---|
+| One-shot prompt, want JSON back | `runtime.response()` |
+| Multi-turn conversation, full message history | `runtime.generate()` |
+| Streaming output to the client | `runtime.stream()` / `streamText()` |
+| Custom tool definitions with handlers, agent loop | `runtime.chat()` with `tools` |
+
+If your call only needs `prompt + responseFormat + maxTokens`,
+`response()` reads cleaner. The other methods give you more knobs for
+free.
+
+---
+
+## Provider routing under the hood
+
+`response()` forwards through the standard adapter pipeline:
+
+- **OpenAI** — when `mcpServers` or `reasoningEffort` is set, routes
+  through `/v1/responses` (Chat Completions doesn't accept these
+  fields). `responseFormat` becomes `text.format`.
+- **Anthropic** — uses `client.beta.messages.*` with the
+  `mcp-client-2025-11-20` beta header when MCP servers are present.
+  `reasoningEffort` maps to adaptive thinking on Claude 4.6/4.7 and
+  `budget_tokens` on older models.
+- **Google / xAI / OpenRouter** — these share the OpenAI adapter via an
+  OpenAI-compatible endpoint. They throw a clear error when `mcpServers`
+  or `reasoningEffort` is set, so fallback chains skip past them.
+
+<Callout type="info">
+  The `store: false` flag is always sent on `/v1/responses` calls —
+  `response()` is one-shot semantics by design, no conversation
+  persistence on OpenAI's side. If you need persistence, use
+  `runtime.chat()` instead.
+</Callout>
+
+---
+
+## Self-learning example
+
+The canonical use case: extract FAQs from a chat transcript, consulting
+a knowledge-base MCP server first to avoid duplicates.
+
+```ts
+const FAQ_SCHEMA = {
+  type: 'object',
+  properties: {
+    response: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          question: { type: 'string' },
+          answer: { type: 'string' },
+          intent: { type: 'string' },
+        },
+        required: ['question', 'answer', 'intent'],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ['response'],
+  additionalProperties: false,
+} as const;
+
+const result = await runtime.response({
+  prompt,
+  systemPrompt: 'Extract FAQs. Consult the KB before creating entries.',
+  mcpServers: [{
+    label: 'knowledge_base',
+    url: 'https://kb.example.com/sse',
+    headers: { Authorization: `Bearer ${env.KB_TOKEN}` },
+    allowedTools: ['search_kb'],
+    requireApproval: 'never',
+  }],
+  reasoningEffort: 'high',
+  responseFormat: {
+    type: 'json_schema',
+    json_schema: { name: 'faqs', schema: FAQ_SCHEMA, strict: true },
+  },
+});
+
+const parsed = JSON.parse(result.text).response;
+```
+
+A working version lives in `examples/fallback-demo` — see the
+`POST /response` route.
+
+---
+
+## Next Steps
+
+- [Structured Output](/docs/llm-sdk/structured-output) — full reference for `responseFormat`, `mcpServers`, `reasoningEffort`
+- [generateText()](/docs/llm-sdk/generate-text) — multi-turn / tool-loop API
+- [Tools](/docs/llm-sdk/tools) — function-calling primitives

--- a/apps/docs/content/docs/llm-sdk/stream-text.mdx
+++ b/apps/docs/content/docs/llm-sdk/stream-text.mdx
@@ -64,11 +64,17 @@ const result = await streamText({
       strict: true,
     },
   },
+
+  // Optional: Remote MCP servers (OpenAI Responses + Anthropic native)
+  mcpServers: [{ label: 'kb', url: 'https://kb.example.com/sse' }],
+
+  // Optional: Reasoning / thinking effort (provider-translated)
+  reasoningEffort: 'medium',
 });
 ```
 
 <Callout>
-  `responseFormat` works across all supported providers — each adapter translates to the provider's native field. See [Structured Output](/docs/llm-sdk/structured-output) for per-provider details and gotchas.
+  `responseFormat`, `mcpServers`, and `reasoningEffort` work across providers via per-adapter translation. See [Structured Output](/docs/llm-sdk/structured-output) for the per-provider mapping tables and gotchas.
 </Callout>
 
 ---

--- a/apps/docs/content/docs/llm-sdk/structured-output.mdx
+++ b/apps/docs/content/docs/llm-sdk/structured-output.mdx
@@ -212,8 +212,131 @@ A working end-to-end demo lives in `examples/fallback-demo` — see the
 
 ---
 
+## MCP servers
+
+Pass `mcpServers` alongside `responseFormat` to let the model call remote
+Model Context Protocol servers as part of the same call. The SDK forwards
+your servers to providers that support MCP natively (OpenAI Responses API,
+Anthropic Messages with `mcp-client-2025-11-20` beta) — no local execution
+or tool wiring required.
+
+```ts
+const result = await runtime.response({
+  prompt: 'Extract FAQs from this conversation. Consult the KB first.',
+  mcpServers: [{
+    label: 'knowledge_base',
+    url: 'https://kb.example.com/sse',
+    headers: { Authorization: `Bearer ${token}` },
+    allowedTools: ['search_kb'],
+    requireApproval: 'never',
+  }],
+  responseFormat: {
+    type: 'json_schema',
+    json_schema: { name: 'faqs', schema: FAQ_SCHEMA, strict: true },
+  },
+});
+```
+
+### McpServerConfig shape
+
+```ts
+interface McpServerConfig {
+  label: string;                          // human-readable, also the MCP server name
+  url: string;                            // HTTP/SSE endpoint
+  headers?: Record<string, string>;       // forwarded as request headers
+  allowedTools?: string[];                // restrict the model to a subset
+  requireApproval?: 'never' | 'always';   // default 'never'
+}
+```
+
+### Per-provider translation
+
+| Provider | Native field | Beta header |
+|---|---|---|
+| OpenAI Responses | `tools[type=mcp]` | — |
+| Anthropic Claude | `mcp_servers` + `tools[type=mcp_toolset]` for `allowedTools` | `mcp-client-2025-11-20` |
+| Google / xAI / Fireworks / OpenRouter / Ollama | _not supported_ | — |
+
+The `Authorization` header is hoisted to Anthropic's top-level
+`authorization_token` with the `Bearer ` prefix stripped — Anthropic
+expects the bare token. Other headers are forwarded verbatim where the
+provider accepts them.
+
+<Callout type="warn">
+  Providers without native MCP throw a clear error today. Use them inside a
+  fallback chain (`retryableErrors: () => true`) and the chain will skip
+  past them to the next provider. Local-execution MCP fallback for
+  Google/xAI/Fireworks/OpenRouter is planned as a follow-up.
+</Callout>
+
+---
+
+## Reasoning effort
+
+Pass `reasoningEffort` for one normalized knob across providers that
+support extended thinking / reasoning. The SDK maps to each provider's
+native shape — `effort` on OpenAI Responses, `thinking.adaptive` on
+Claude 4.6/4.7, `thinking.budget_tokens` on older Claude.
+
+```ts
+const result = await runtime.response({
+  prompt: 'Plan the data migration step by step.',
+  reasoningEffort: 'high',
+});
+```
+
+### Type
+
+```ts
+type ReasoningEffort =
+  | 'minimal' | 'low' | 'medium' | 'high'  // normalized enum
+  | { budgetTokens: number }                // explicit Anthropic / Gemini budget
+  | { raw: Record<string, unknown> };       // provider passthrough escape hatch
+```
+
+### Per-provider translation
+
+| Provider | Native field | Notes |
+|---|---|---|
+| OpenAI Responses | `reasoning: { effort, summary: 'auto' }` | `minimal`/`low`/`medium`/`high` (plus `xhigh`/`none` if passed via `{ raw }`) |
+| Anthropic Claude 4.6 / 4.7 | `thinking: { type: 'adaptive', effort }` | Preferred for new models |
+| Anthropic Claude 3.7 / 4.0–4.5 | `thinking: { type: 'enabled', budget_tokens }` | Buckets: low=4k, medium=8k, high=16k |
+| Google Gemini 2.5/3.x thinking models | `thinkingConfig.thinkingBudget` | Buckets: 1k / 4k / 8k / 24k |
+| xAI Grok | `reasoning_effort` | Coerced to `low`/`high` only |
+| Others | _silently ignored_ | The model still runs, just without extended reasoning |
+
+### When to use `budgetTokens` vs the enum
+
+The enum is the right default. Use `{ budgetTokens: N }` only when you
+need an exact token count — typically for cost control on Anthropic
+older models or Gemini. The escape hatch `{ raw: {...} }` forwards your
+object literally to the provider with no translation.
+
+---
+
+## runtime.response() — one-shot bundle
+
+For the common "prompt in, JSON out" case use the convenience method:
+
+```ts
+const result = await runtime.response({
+  prompt,
+  mcpServers: [...],
+  reasoningEffort: 'high',
+  responseFormat: { type: 'json_schema', json_schema: {...} },
+});
+const data = JSON.parse(result.text);
+```
+
+It's a thin wrapper over `runtime.generate()` that builds the single
+user-message and forwards the request config. See
+[runtime.response()](/docs/llm-sdk/response) for the full reference.
+
+---
+
 ## Next Steps
 
 - [generateText()](/docs/llm-sdk/generate-text) — full text generation API
 - [streamText()](/docs/llm-sdk/stream-text) — streaming variant
+- [runtime.response()](/docs/llm-sdk/response) — one-shot MCP + reasoning + schema
 - [Tools](/docs/llm-sdk/tools) — function calling (orthogonal to structured output)

--- a/apps/docs/content/docs/llm-sdk/structured-output.mdx
+++ b/apps/docs/content/docs/llm-sdk/structured-output.mdx
@@ -275,8 +275,9 @@ provider accepts them.
 
 Pass `reasoningEffort` for one normalized knob across providers that
 support extended thinking / reasoning. The SDK maps to each provider's
-native shape — `effort` on OpenAI Responses, `thinking.adaptive` on
-Claude 4.6/4.7, `thinking.budget_tokens` on older Claude.
+native shape — `reasoning.effort` on OpenAI Responses (reasoning models
+only), `thinking.adaptive` + `output_config.effort` on Claude 4.6/4.7,
+`thinking.budget_tokens` on older Claude.
 
 ```ts
 const result = await runtime.response({
@@ -298,8 +299,8 @@ type ReasoningEffort =
 
 | Provider | Native field | Notes |
 |---|---|---|
-| OpenAI Responses | `reasoning: { effort, summary: 'auto' }` | `minimal`/`low`/`medium`/`high` (plus `xhigh`/`none` if passed via `{ raw }`) |
-| Anthropic Claude 4.6 / 4.7 | `thinking: { type: 'adaptive', effort }` | Preferred for new models |
+| OpenAI Responses (o-series / gpt-5.x only) | `reasoning: { effort, summary: 'auto' }` | `minimal`/`low`/`medium`/`high` (plus `xhigh`/`none` if passed via `{ raw }`). Ignored on non-reasoning models like `gpt-4o` with a warning |
+| Anthropic Claude 4.6 / 4.7 | `thinking: { type: 'adaptive' }` + `output_config: { effort }` | Effort lives on `output_config`, not inside `thinking` |
 | Anthropic Claude 3.7 / 4.0–4.5 | `thinking: { type: 'enabled', budget_tokens }` | Buckets: low=4k, medium=8k, high=16k |
 | Google Gemini 2.5/3.x thinking models | `thinkingConfig.thinkingBudget` | Buckets: 1k / 4k / 8k / 24k |
 | xAI Grok | `reasoning_effort` | Coerced to `low`/`high` only |

--- a/apps/docs/content/docs/providers/anthropic.mdx
+++ b/apps/docs/content/docs/providers/anthropic.mdx
@@ -203,6 +203,70 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
 ---
 
+## MCP servers
+
+Anthropic supports remote Model Context Protocol servers natively via the
+Messages API. Pass `mcpServers` on the request config and the SDK routes
+through `client.beta.messages.*` with the required beta header.
+
+```ts
+const result = await runtime.response({
+  prompt: 'Create a GitHub issue summarizing the deploy failures.',
+  mcpServers: [{
+    label: 'github',
+    url: 'https://mcp.github.com/sse',
+    headers: { Authorization: `Bearer ${process.env.GH_TOKEN}` },
+    allowedTools: ['create_issue', 'search_issues'],
+  }],
+});
+```
+
+Beta header attached automatically: `anthropic-beta: mcp-client-2025-11-20`.
+
+The shape sent to Anthropic uses the 2025-11-20 two-array form:
+- `mcp_servers: [{ type: "url", url, name, authorization_token }]` — connection entries (the SDK strips `Bearer ` from the `Authorization` header value, since Anthropic expects the bare token).
+- `tools: [{ type: "mcp_toolset", mcp_server_name, configs: {...} }]` — tool filtering (only emitted when `allowedTools` is set).
+
+See [Structured Output → MCP servers](/docs/llm-sdk/structured-output#mcp-servers) for the cross-provider reference.
+
+---
+
+## Extended thinking
+
+Two ways to enable Claude's extended thinking:
+
+**Per-request** (recommended) — pass `reasoningEffort` on the call. The
+SDK picks the right shape for the model:
+
+```ts
+const result = await runtime.response({
+  prompt: 'Plan a multi-step refactor of the auth flow.',
+  reasoningEffort: 'high',
+});
+```
+
+- **Claude 4.6 / 4.7** (Opus 4.7, Sonnet 4.6, Opus 4.6): adaptive thinking — `thinking: { type: 'adaptive', effort: 'high' }`. The model chooses budget dynamically based on effort.
+- **Claude 3.7 / 4.0 / 4.5 series**: explicit budget — `thinking: { type: 'enabled', budget_tokens: 16000 }`. Buckets: `low=4k`, `medium=8k`, `high=16k`. Pass `{ budgetTokens: N }` for an exact number.
+
+<Callout type="warn">
+  `budget_tokens` is deprecated on Claude 4.6 and Sonnet 4.6. Use the
+  `reasoningEffort` enum and the SDK picks adaptive mode automatically
+  on those models.
+</Callout>
+
+**Per-adapter** (legacy) — set `thinking` on `createAnthropic()` config.
+Per-request `reasoningEffort` overrides the adapter default when both
+are set.
+
+```ts
+const anthropic = createAnthropic({
+  apiKey: process.env.ANTHROPIC_API_KEY,
+  thinking: { type: 'enabled', budgetTokens: 8000 },
+});
+```
+
+---
+
 ## Pricing
 
 | Model | Input | Output |

--- a/apps/docs/content/docs/providers/anthropic.mdx
+++ b/apps/docs/content/docs/providers/anthropic.mdx
@@ -245,8 +245,8 @@ const result = await runtime.response({
 });
 ```
 
-- **Claude 4.6 / 4.7** (Opus 4.7, Sonnet 4.6, Opus 4.6): adaptive thinking — `thinking: { type: 'adaptive', effort: 'high' }`. The model chooses budget dynamically based on effort.
-- **Claude 3.7 / 4.0 / 4.5 series**: explicit budget — `thinking: { type: 'enabled', budget_tokens: 16000 }`. Buckets: `low=4k`, `medium=8k`, `high=16k`. Pass `{ budgetTokens: N }` for an exact number.
+- **Claude 4.6 / 4.7** (Opus 4.7, Sonnet 4.6, Opus 4.6): adaptive thinking. The SDK emits `thinking: { type: 'adaptive' }` (no effort inside) and merges the effort into `output_config.effort` alongside `format`. This is the shape the API requires — sending the legacy `{ type: 'enabled', budget_tokens }` to these models returns `400 "thinking.type.enabled" is not supported for this model`.
+- **Claude 3.7 / 4.0 / 4.5 series**: explicit budget — `thinking: { type: 'enabled', budget_tokens: 16000 }`. Buckets: `low=4k`, `medium=8k`, `high=16k`. Pass `{ budgetTokens: N }` for an exact number. These models reject `adaptive`.
 
 <Callout type="warn">
   `budget_tokens` is deprecated on Claude 4.6 and Sonnet 4.6. Use the

--- a/apps/docs/content/docs/providers/openai.mdx
+++ b/apps/docs/content/docs/providers/openai.mdx
@@ -177,6 +177,42 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
 ---
 
+## MCP servers + Reasoning effort (Responses API)
+
+Setting `mcpServers` or `reasoningEffort` on a request routes the call
+through OpenAI's `/v1/responses` endpoint instead of Chat Completions
+(those fields aren't accepted on Chat Completions).
+
+```ts
+const result = await runtime.response({
+  prompt: 'Create a GitHub issue with the latest deploy errors.',
+  mcpServers: [{
+    label: 'github',
+    url: 'https://mcp.github.com/sse',
+    headers: { Authorization: `Bearer ${process.env.GH_TOKEN}` },
+    allowedTools: ['create_issue'],
+    requireApproval: 'never',
+  }],
+  reasoningEffort: 'high',
+});
+```
+
+Maps to:
+- `tools: [{ type: 'mcp', server_label, server_url, headers, allowed_tools, require_approval }]`
+- `reasoning: { effort: 'high', summary: 'auto' }`
+- `store: false` (one-shot semantics — no persistence on OpenAI's side)
+- `text.format` when `responseFormat` is also set
+
+<Callout type="info">
+  `reasoningEffort` accepts `minimal`/`low`/`medium`/`high` directly.
+  Use `{ raw: { effort: 'xhigh' } }` to pass the wider native range
+  (`none`/`xhigh`) for o-series and gpt-5 reasoning models.
+</Callout>
+
+See [Structured Output → MCP servers](/docs/llm-sdk/structured-output#mcp-servers) and [→ Reasoning effort](/docs/llm-sdk/structured-output#reasoning-effort) for the cross-provider reference.
+
+---
+
 ## Pricing
 
 | Model | Input | Output |

--- a/examples/fallback-demo/src/index.ts
+++ b/examples/fallback-demo/src/index.ts
@@ -452,14 +452,34 @@ const FAQ_SCHEMA = {
   additionalProperties: false,
 } as const;
 
+// Uses a reasoning-capable model (gpt-5.2) so `reasoningEffort` actually
+// engages the Responses API reasoning field. gpt-4o would have it silently
+// dropped because OpenAI only accepts `reasoning.effort` on o-series / gpt-5.x.
+// Uses a reasoning-capable model (gpt-5.2) so `reasoningEffort` actually
+// engages the Responses API reasoning field. gpt-4o would have it silently
+// dropped because OpenAI only accepts `reasoning.effort` on o-series / gpt-5.x.
 const responsesRuntime = createRuntime({
   adapter: createFallbackChain({
     models: [
-      openai.languageModel("gpt-4o"),
+      openai.languageModel("gpt-5.2"),
       anthropic.languageModel("claude-opus-4-7"),
     ],
     strategy: "priority",
     onFallback: onFallbackLog("response"),
+  }),
+});
+
+// Smoke-test route: dead OpenAI primary → forces Anthropic fallback for the
+// Responses bundle. Exercises the `mcp-client-2025-11-20` beta header path
+// (when mcpServers is set) and adaptive thinking on Claude 4.7.
+const responsesAnthropicRuntime = createRuntime({
+  adapter: createFallbackChain({
+    models: [
+      deadOpenAI.languageModel("gpt-5.2"),
+      anthropic.languageModel("claude-opus-4-7"),
+    ],
+    strategy: "priority",
+    onFallback: onFallbackLog("response-claude-forced"),
   }),
 });
 
@@ -503,7 +523,54 @@ app.post("/response", async (req, res) => {
       }
     })();
 
-    res.json({ raw: result.text, parsed });
+    res.json({ raw: result.text, parsed, usage: result.usage });
+  } catch (err) {
+    handleError(err, res);
+  }
+});
+
+// Force the Anthropic hop on the Responses bundle (dead OpenAI primary).
+app.post("/response/claude", async (req, res) => {
+  try {
+    const { prompt, mcpUrl, mcpToken } = req.body as {
+      prompt: string;
+      mcpUrl?: string;
+      mcpToken?: string;
+    };
+
+    const result = await responsesAnthropicRuntime.response({
+      prompt,
+      systemPrompt:
+        "You are an FAQ extractor. Consult the knowledge-base MCP server before creating new entries.",
+      mcpServers: mcpUrl
+        ? [
+            {
+              label: "knowledge_base",
+              url: mcpUrl,
+              headers: mcpToken
+                ? { Authorization: `Bearer ${mcpToken}` }
+                : undefined,
+              allowedTools: ["internal_knowledgebase"],
+              requireApproval: "never",
+            },
+          ]
+        : undefined,
+      reasoningEffort: "high",
+      responseFormat: {
+        type: "json_schema",
+        json_schema: { name: "faqs", schema: FAQ_SCHEMA, strict: true },
+      },
+    });
+
+    const parsed = (() => {
+      try {
+        return JSON.parse(result.text);
+      } catch {
+        return null;
+      }
+    })();
+
+    res.json({ raw: result.text, parsed, usage: result.usage });
   } catch (err) {
     handleError(err, res);
   }

--- a/examples/fallback-demo/src/index.ts
+++ b/examples/fallback-demo/src/index.ts
@@ -415,6 +415,100 @@ app.post("/chat/structured", async (req, res) => {
   }
 });
 
+// ─── Route: Responses API bundle (MCP + reasoning + schema) ──────────────────
+//
+// Single-call response() that bundles MCP server passthrough, reasoning effort
+// control, and JSON-schema structured output. Mirrors the self-learning use
+// case in production: extract FAQ pairs from a transcript while letting the
+// model consult a knowledge-base MCP server first.
+//
+// OpenAI routes through /v1/responses; Anthropic falls back to /v1/messages
+// with the `mcp-client-2025-11-20` beta header. Providers without native MCP
+// (Google/xAI/OpenRouter) throw a clear error so the fallback chain skips them.
+//
+// Test:
+//   curl -s -X POST http://localhost:3000/response \
+//     -H "Content-Type: application/json" \
+//     -d '{"prompt":"Operator told a user the refund window is 30 days. Extract FAQs.","mcpUrl":"https://kb.example.com/sse","mcpToken":"…"}'
+
+const FAQ_SCHEMA = {
+  type: "object",
+  properties: {
+    response: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          question: { type: "string" },
+          answer: { type: "string" },
+          intent: { type: "string" },
+        },
+        required: ["question", "answer", "intent"],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ["response"],
+  additionalProperties: false,
+} as const;
+
+const responsesRuntime = createRuntime({
+  adapter: createFallbackChain({
+    models: [
+      openai.languageModel("gpt-4o"),
+      anthropic.languageModel("claude-opus-4-7"),
+    ],
+    strategy: "priority",
+    onFallback: onFallbackLog("response"),
+  }),
+});
+
+app.post("/response", async (req, res) => {
+  try {
+    const { prompt, mcpUrl, mcpToken } = req.body as {
+      prompt: string;
+      mcpUrl?: string;
+      mcpToken?: string;
+    };
+
+    const result = await responsesRuntime.response({
+      prompt,
+      systemPrompt:
+        "You are an FAQ extractor. Consult the knowledge-base MCP server before creating new entries.",
+      mcpServers: mcpUrl
+        ? [
+            {
+              label: "knowledge_base",
+              url: mcpUrl,
+              headers: mcpToken
+                ? { Authorization: `Bearer ${mcpToken}` }
+                : undefined,
+              allowedTools: ["internal_knowledgebase"],
+              requireApproval: "never",
+            },
+          ]
+        : undefined,
+      reasoningEffort: "high",
+      responseFormat: {
+        type: "json_schema",
+        json_schema: { name: "faqs", schema: FAQ_SCHEMA, strict: true },
+      },
+    });
+
+    const parsed = (() => {
+      try {
+        return JSON.parse(result.text);
+      } catch {
+        return null;
+      }
+    })();
+
+    res.json({ raw: result.text, parsed });
+  } catch (err) {
+    handleError(err, res);
+  }
+});
+
 // ─── Route 7: Tools + FORCED FALLBACK (dead primary) ─────────────────────────
 //
 // Same tools, but primary is a dead URL.
@@ -488,5 +582,8 @@ app.listen(PORT, () => {
   );
   console.log(
     "  POST /chat/structured          — JSON-schema response across OpenAI → Claude → Gemini",
+  );
+  console.log(
+    "  POST /response                 — runtime.response() with MCP + reasoning + schema (OpenAI → Claude)",
   );
 });

--- a/examples/fallback-demo/src/index.ts
+++ b/examples/fallback-demo/src/index.ts
@@ -653,4 +653,7 @@ app.listen(PORT, () => {
   console.log(
     "  POST /response                 — runtime.response() with MCP + reasoning + schema (OpenAI → Claude)",
   );
+  console.log(
+    "  POST /response/claude          — same as above, dead OpenAI primary → forces Anthropic",
+  );
 });

--- a/packages/llm-sdk/README.md
+++ b/packages/llm-sdk/README.md
@@ -114,6 +114,24 @@ const runtime = createRuntime({
 
 When `search.enabled` is on, deferred tools can be discovered through a hidden `search_tools` server tool. Matching tools are loaded into the next loop iteration instead of sending every deferred tool definition up front.
 
+## Structured output, MCP, and reasoning effort
+
+Pass `responseFormat`, `mcpServers`, and `reasoningEffort` on any `generateText()` / `streamText()` / `runtime.chat()` / `runtime.response()` call:
+
+```ts
+const result = await runtime.response({
+  prompt: "Extract FAQs from this conversation.",
+  mcpServers: [{ label: "kb", url: "https://kb.example.com/sse" }],
+  reasoningEffort: "high",
+  responseFormat: {
+    type: "json_schema",
+    json_schema: { name, schema, strict: true },
+  },
+});
+```
+
+OpenAI routes through `/v1/responses` automatically when MCP or reasoning is set; Anthropic uses the `mcp-client-2025-11-20` beta and adaptive thinking on Claude 4.6/4.7. See the [Structured Output guide](https://copilot-sdk.yourgpt.ai/docs/llm-sdk/structured-output) for the full per-provider mapping.
+
 ## Documentation
 
 Visit **[copilot-sdk.yourgpt.ai](https://copilot-sdk.yourgpt.ai)** for full documentation:
@@ -121,7 +139,7 @@ Visit **[copilot-sdk.yourgpt.ai](https://copilot-sdk.yourgpt.ai)** for full docu
 - [All Providers](https://copilot-sdk.yourgpt.ai/docs/providers) - OpenAI, Anthropic, Google, xAI
 - [Server Setup](https://copilot-sdk.yourgpt.ai/docs/server) - Runtime, streaming, tools
 - [Tools](https://copilot-sdk.yourgpt.ai/docs/tools) - Server-side and client-side tools
-- [LLM SDK Reference](https://copilot-sdk.yourgpt.ai/docs/llm-sdk) - streamText, generateText
+- [LLM SDK Reference](https://copilot-sdk.yourgpt.ai/docs/llm-sdk) - streamText, generateText, runtime.response()
 
 ## License
 

--- a/packages/llm-sdk/package.json
+++ b/packages/llm-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yourgpt/llm-sdk",
-  "version": "2.5.0",
+  "version": "2.5.1-beta.1",
   "description": "AI SDK for building AI Agents with any LLM",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/llm-sdk/src/adapters/anthropic.ts
+++ b/packages/llm-sdk/src/adapters/anthropic.ts
@@ -515,24 +515,33 @@ export class AnthropicAdapter implements LLMAdapter {
       options.server_tool_configuration = serverToolConfiguration;
     }
 
-    // Anthropic structured output (`output_config.format`) — GA on Claude API
-    // and Bedrock as of late 2025. Vertex AI does not support it; users on
-    // Vertex should use a forced-tool pattern via `actions` + `toolChoice`.
-    const outputConfig = toAnthropicOutputConfig(responseFormat);
-    if (outputConfig) {
-      options.output_config = outputConfig;
-    }
-
-    // Per-request reasoning effort wins over adapter-level `thinking` config.
-    // For Claude 4.6/4.7 we emit the adaptive shape; older models fall back to
-    // explicit `budget_tokens`.
+    // Anthropic structured output + reasoning effort.
+    //
+    // Claude 4.6/4.7 require `thinking: { type: "adaptive" }` with the
+    // effort knob living on `output_config.effort` (not inside `thinking`).
+    // Older Claude models accept `thinking: { type: "enabled", budget_tokens }`
+    // and have no `output_config.effort` concept. Both are coordinated below.
     const modelForThinking = (request.config?.model || this.model) as string;
-    const requestThinking = toAnthropicThinking(
+    const thinkingTranslation = toAnthropicThinking(
       request.config?.reasoningEffort,
       modelForThinking,
     );
-    if (requestThinking) {
-      options.thinking = requestThinking;
+
+    const outputConfig = toAnthropicOutputConfig(responseFormat) as
+      | Record<string, unknown>
+      | undefined;
+    if (outputConfig || thinkingTranslation.outputConfigEffort) {
+      options.output_config = {
+        ...(outputConfig ?? {}),
+        ...(thinkingTranslation.outputConfigEffort
+          ? { effort: thinkingTranslation.outputConfigEffort }
+          : {}),
+      };
+    }
+
+    // Per-request reasoning wins over adapter-level `thinking` config.
+    if (thinkingTranslation.thinking) {
+      options.thinking = thinkingTranslation.thinking;
     } else if (this.config.thinking?.type === "enabled") {
       options.thinking = {
         type: "enabled",

--- a/packages/llm-sdk/src/adapters/anthropic.ts
+++ b/packages/llm-sdk/src/adapters/anthropic.ts
@@ -16,6 +16,8 @@ import {
   messageToAnthropicContent,
   logProviderPayload,
   toAnthropicOutputConfig,
+  toAnthropicMcp,
+  toAnthropicThinking,
   type AnthropicContentBlock,
 } from "./base";
 
@@ -377,6 +379,7 @@ export class AnthropicAdapter implements LLMAdapter {
   private buildRequestOptions(request: ChatCompletionRequest): {
     options: Record<string, unknown>;
     messages: Array<Record<string, unknown>>;
+    betas: string[];
   } {
     // Extract system message; Anthropic has no schema-less JSON mode, so for
     // `responseFormat.type === "json_object"` we coerce via a system suffix.
@@ -520,15 +523,40 @@ export class AnthropicAdapter implements LLMAdapter {
       options.output_config = outputConfig;
     }
 
-    // Add thinking configuration if enabled
-    if (this.config.thinking?.type === "enabled") {
+    // Per-request reasoning effort wins over adapter-level `thinking` config.
+    // For Claude 4.6/4.7 we emit the adaptive shape; older models fall back to
+    // explicit `budget_tokens`.
+    const modelForThinking = (request.config?.model || this.model) as string;
+    const requestThinking = toAnthropicThinking(
+      request.config?.reasoningEffort,
+      modelForThinking,
+    );
+    if (requestThinking) {
+      options.thinking = requestThinking;
+    } else if (this.config.thinking?.type === "enabled") {
       options.thinking = {
         type: "enabled",
         budget_tokens: this.config.thinking.budgetTokens || 10000,
       };
     }
 
-    return { options, messages };
+    // MCP server passthrough — `mcp-client-2025-11-20` shape: `mcp_servers`
+    // holds the connection entries, and tool filtering is expressed as
+    // `tools[type=mcp_toolset]` entries spliced alongside the function tools.
+    const mcp = toAnthropicMcp(request.config?.mcpServers);
+    const betas: string[] = [];
+    if (mcp.mcpServers.length > 0) {
+      options.mcp_servers = mcp.mcpServers;
+      betas.push(...mcp.betas);
+      if (mcp.tools.length > 0) {
+        const existingTools = Array.isArray(options.tools)
+          ? (options.tools as Array<Record<string, unknown>>)
+          : [];
+        options.tools = [...existingTools, ...mcp.tools];
+      }
+    }
+
+    return { options, messages, betas };
   }
 
   /**
@@ -536,7 +564,7 @@ export class AnthropicAdapter implements LLMAdapter {
    */
   async complete(request: ChatCompletionRequest): Promise<CompletionResult> {
     const client = await this.getClient();
-    const { options } = this.buildRequestOptions(request);
+    const { options, betas } = this.buildRequestOptions(request);
 
     // Ensure non-streaming mode
     const nonStreamingOptions = {
@@ -548,10 +576,18 @@ export class AnthropicAdapter implements LLMAdapter {
       logProviderPayload(
         "anthropic",
         "request payload",
-        nonStreamingOptions,
+        { ...nonStreamingOptions, _betas: betas },
         request.debug,
       );
-      const response = await client.messages.create(nonStreamingOptions);
+      // When MCP (or any other beta) is in use, route through the `beta.*`
+      // namespace so the SDK attaches the `anthropic-beta` header for us.
+      const messagesApi =
+        betas.length > 0 ? client.beta.messages : client.messages;
+      const createOptions = betas.length > 0 ? { betas } : undefined;
+      const response = await messagesApi.create(
+        nonStreamingOptions,
+        createOptions as never,
+      );
       logProviderPayload(
         "anthropic",
         "response payload",
@@ -595,7 +631,7 @@ export class AnthropicAdapter implements LLMAdapter {
 
   async *stream(request: ChatCompletionRequest): AsyncGenerator<StreamEvent> {
     const client = await this.getClient();
-    const { options } = this.buildRequestOptions(request);
+    const { options, betas } = this.buildRequestOptions(request);
 
     const messageId = generateMessageId();
 
@@ -606,10 +642,13 @@ export class AnthropicAdapter implements LLMAdapter {
       logProviderPayload(
         "anthropic",
         "request payload",
-        options,
+        { ...options, _betas: betas },
         request.debug,
       );
-      const stream = await client.messages.stream(options);
+      const streamApi =
+        betas.length > 0 ? client.beta.messages : client.messages;
+      const streamOptions = betas.length > 0 ? { betas } : undefined;
+      const stream = await streamApi.stream(options, streamOptions as never);
 
       let currentToolUse: {
         id: string;

--- a/packages/llm-sdk/src/adapters/anthropic.ts
+++ b/packages/llm-sdk/src/adapters/anthropic.ts
@@ -573,21 +573,23 @@ export class AnthropicAdapter implements LLMAdapter {
     } as Record<string, unknown> & { stream: false };
 
     try {
+      // When MCP (or any other beta) is in use, route through the `beta.*`
+      // namespace so the SDK attaches the `anthropic-beta` header for us.
+      // The Anthropic SDK expects `betas` *inside the params object* on
+      // BetaMessageCreateParams, not as a separate RequestOptions argument.
+      const finalOptions =
+        betas.length > 0
+          ? { ...nonStreamingOptions, betas }
+          : nonStreamingOptions;
+      const messagesApi =
+        betas.length > 0 ? client.beta.messages : client.messages;
       logProviderPayload(
         "anthropic",
         "request payload",
-        { ...nonStreamingOptions, _betas: betas },
+        finalOptions,
         request.debug,
       );
-      // When MCP (or any other beta) is in use, route through the `beta.*`
-      // namespace so the SDK attaches the `anthropic-beta` header for us.
-      const messagesApi =
-        betas.length > 0 ? client.beta.messages : client.messages;
-      const createOptions = betas.length > 0 ? { betas } : undefined;
-      const response = await messagesApi.create(
-        nonStreamingOptions,
-        createOptions as never,
-      );
+      const response = await messagesApi.create(finalOptions);
       logProviderPayload(
         "anthropic",
         "response payload",
@@ -639,16 +641,18 @@ export class AnthropicAdapter implements LLMAdapter {
     yield { type: "message:start", id: messageId };
 
     try {
+      // `betas` must live inside the params object on BetaMessageCreateParams
+      // (not the second RequestOptions argument).
+      const finalOptions = betas.length > 0 ? { ...options, betas } : options;
+      const streamApi =
+        betas.length > 0 ? client.beta.messages : client.messages;
       logProviderPayload(
         "anthropic",
         "request payload",
-        { ...options, _betas: betas },
+        finalOptions,
         request.debug,
       );
-      const streamApi =
-        betas.length > 0 ? client.beta.messages : client.messages;
-      const streamOptions = betas.length > 0 ? { betas } : undefined;
-      const stream = await streamApi.stream(options, streamOptions as never);
+      const stream = await streamApi.stream(finalOptions);
 
       let currentToolUse: {
         id: string;

--- a/packages/llm-sdk/src/adapters/base.ts
+++ b/packages/llm-sdk/src/adapters/base.ts
@@ -573,31 +573,56 @@ export function toOpenAIReasoning(
 }
 
 /**
- * Anthropic `thinking` block.
+ * Anthropic thinking + effort translation.
  *
- * Claude 4.6 / 4.7 prefer adaptive thinking with an `effort` knob — older
- * Claude (3.7 / 4.x baseline) still accept `budget_tokens`. Models that don't
- * support extended thinking return undefined.
+ * Verified live against the API (May 2026):
+ *   - Claude Opus 4.7 REJECTS `{ type: "enabled", budget_tokens }`:
+ *     > `"thinking.type.enabled" is not supported for this model. Use
+ *     > "thinking.type.adaptive" and "output_config.effort" to control
+ *     > thinking behavior.`
+ *     The adaptive mode takes NO effort knob inside `thinking` — effort
+ *     moves to `output_config.effort` as a sibling of `output_config.format`.
+ *   - Older Claude (3.7 / 4.0 / 4.5) accept the legacy
+ *     `{ type: "enabled", budget_tokens }` shape and reject `adaptive`.
+ *
+ * Returns a struct so the adapter can splice each piece into the right
+ * place — thinking block goes top-level, outputConfigEffort merges into
+ * `output_config` alongside `format`.
  */
+export interface AnthropicThinkingTranslation {
+  thinking?: Record<string, unknown>;
+  outputConfigEffort?: "low" | "medium" | "high";
+}
+
+const ANTHROPIC_ADAPTIVE_MODELS =
+  /(claude-opus-4-7|claude-opus-4-6|claude-sonnet-4-6)/i;
+
 export function toAnthropicThinking(
   effort: ReasoningEffort | undefined,
   modelId: string | undefined,
-): Record<string, unknown> | undefined {
-  if (!effort) return undefined;
-  if (typeof effort === "object" && "raw" in effort) return effort.raw;
-
-  const isAdaptive =
-    !!modelId &&
-    /(claude-opus-4-7|claude-sonnet-4-6|claude-opus-4-6)/i.test(modelId);
-
-  if (typeof effort === "object" && "budgetTokens" in effort) {
-    return { type: "enabled", budget_tokens: effort.budgetTokens };
+): AnthropicThinkingTranslation {
+  if (!effort) return {};
+  if (typeof effort === "object" && "raw" in effort) {
+    return { thinking: effort.raw };
   }
 
-  if (!isStringEffort(effort)) return undefined;
+  const isAdaptive = !!modelId && ANTHROPIC_ADAPTIVE_MODELS.test(modelId);
+
+  if (typeof effort === "object" && "budgetTokens" in effort) {
+    return {
+      thinking: { type: "enabled", budget_tokens: effort.budgetTokens },
+    };
+  }
+
+  if (!isStringEffort(effort)) return {};
 
   if (isAdaptive) {
-    return { type: "adaptive", effort };
+    // `minimal` isn't a documented adaptive effort value — bucket to "low".
+    const mapped = effort === "minimal" ? "low" : effort;
+    return {
+      thinking: { type: "adaptive" },
+      outputConfigEffort: mapped,
+    };
   }
 
   const budget =
@@ -608,7 +633,7 @@ export function toAnthropicThinking(
         : effort === "low"
           ? 4000
           : 2048;
-  return { type: "enabled", budget_tokens: budget };
+  return { thinking: { type: "enabled", budget_tokens: budget } };
 }
 
 /**

--- a/packages/llm-sdk/src/adapters/base.ts
+++ b/packages/llm-sdk/src/adapters/base.ts
@@ -8,6 +8,8 @@ import type {
   ToolDefinition,
   WebSearchConfig,
   ProviderToolRuntimeOptions,
+  McpServerConfig,
+  ReasoningEffort,
 } from "../core/stream-events";
 import type { TokenUsage } from "../core/types";
 
@@ -19,6 +21,10 @@ export interface RequestLLMConfig {
   temperature?: number;
   maxTokens?: number;
   responseFormat?: ResponseFormat;
+  /** MCP servers exposed to the model for this request (provider-translated). */
+  mcpServers?: McpServerConfig[];
+  /** Reasoning/thinking effort knob (provider-translated). */
+  reasoningEffort?: ReasoningEffort;
 }
 
 /**
@@ -451,6 +457,200 @@ export function toOllamaFormat(
   if (!rf) return undefined;
   if (rf.type === "json_object") return "json";
   return rf.json_schema.schema;
+}
+
+// ============================================
+// MCP server translators
+// ============================================
+
+/**
+ * OpenAI Responses-API `tools[type=mcp]` entries. The Responses endpoint
+ * accepts MCP server references inline alongside function tools.
+ */
+export function toOpenAIResponsesMcpTools(
+  mcpServers: McpServerConfig[] | undefined,
+): Array<Record<string, unknown>> {
+  if (!mcpServers || mcpServers.length === 0) return [];
+  return mcpServers.map((mcp) => ({
+    type: "mcp",
+    server_label: mcp.label,
+    server_url: mcp.url,
+    ...(mcp.headers ? { headers: mcp.headers } : {}),
+    ...(mcp.allowedTools ? { allowed_tools: mcp.allowedTools } : {}),
+    require_approval: mcp.requireApproval ?? "never",
+  }));
+}
+
+/**
+ * Anthropic `mcp-client-2025-11-20` payload split.
+ *
+ * The 2025-11-20 beta moved tool filtering out of the `mcp_servers` entry
+ * into a separate `tools[type=mcp_toolset]` entry. We emit both pieces from a
+ * single `McpServerConfig` so adapters can splice them into the request.
+ *
+ * The `Authorization` header is hoisted to the top-level `authorization_token`
+ * field with the `Bearer ` prefix stripped (Anthropic expects the bare token).
+ */
+export function toAnthropicMcp(mcpServers: McpServerConfig[] | undefined): {
+  mcpServers: Array<Record<string, unknown>>;
+  tools: Array<Record<string, unknown>>;
+  betas: string[];
+} {
+  if (!mcpServers || mcpServers.length === 0) {
+    return { mcpServers: [], tools: [], betas: [] };
+  }
+
+  const serverEntries: Array<Record<string, unknown>> = [];
+  const toolEntries: Array<Record<string, unknown>> = [];
+
+  for (const mcp of mcpServers) {
+    const authHeader = mcp.headers?.Authorization ?? mcp.headers?.authorization;
+    const token = authHeader?.replace(/^Bearer\s+/i, "");
+
+    serverEntries.push({
+      type: "url",
+      url: mcp.url,
+      name: mcp.label,
+      ...(token ? { authorization_token: token } : {}),
+    });
+
+    if (mcp.allowedTools && mcp.allowedTools.length > 0) {
+      toolEntries.push({
+        type: "mcp_toolset",
+        mcp_server_name: mcp.label,
+        configs: Object.fromEntries(
+          mcp.allowedTools.map((toolName) => [toolName, {}]),
+        ),
+      });
+    }
+  }
+
+  return {
+    mcpServers: serverEntries,
+    tools: toolEntries,
+    betas: ["mcp-client-2025-11-20"],
+  };
+}
+
+// ============================================
+// Reasoning-effort translators
+// ============================================
+
+function isStringEffort(
+  effort: ReasoningEffort | undefined,
+): effort is "minimal" | "low" | "medium" | "high" {
+  return (
+    typeof effort === "string" &&
+    (effort === "minimal" ||
+      effort === "low" ||
+      effort === "medium" ||
+      effort === "high")
+  );
+}
+
+/**
+ * OpenAI Responses-API `reasoning` block.
+ *
+ * Returns undefined when no effort is configured; otherwise emits the
+ * provider-native `{ effort, summary: "auto" }` shape. Raw escape hatches
+ * pass through unchanged.
+ */
+export function toOpenAIReasoning(
+  effort: ReasoningEffort | undefined,
+): Record<string, unknown> | undefined {
+  if (!effort) return undefined;
+  if (typeof effort === "object" && "raw" in effort) return effort.raw;
+  if (typeof effort === "object" && "budgetTokens" in effort) {
+    // OpenAI doesn't take an explicit budget — fold it down to a coarse effort.
+    const budget = effort.budgetTokens;
+    const mapped = budget >= 16000 ? "high" : budget >= 8000 ? "medium" : "low";
+    return { effort: mapped, summary: "auto" };
+  }
+  if (isStringEffort(effort)) {
+    return { effort, summary: "auto" };
+  }
+  return undefined;
+}
+
+/**
+ * Anthropic `thinking` block.
+ *
+ * Claude 4.6 / 4.7 prefer adaptive thinking with an `effort` knob — older
+ * Claude (3.7 / 4.x baseline) still accept `budget_tokens`. Models that don't
+ * support extended thinking return undefined.
+ */
+export function toAnthropicThinking(
+  effort: ReasoningEffort | undefined,
+  modelId: string | undefined,
+): Record<string, unknown> | undefined {
+  if (!effort) return undefined;
+  if (typeof effort === "object" && "raw" in effort) return effort.raw;
+
+  const isAdaptive =
+    !!modelId &&
+    /(claude-opus-4-7|claude-sonnet-4-6|claude-opus-4-6)/i.test(modelId);
+
+  if (typeof effort === "object" && "budgetTokens" in effort) {
+    return { type: "enabled", budget_tokens: effort.budgetTokens };
+  }
+
+  if (!isStringEffort(effort)) return undefined;
+
+  if (isAdaptive) {
+    return { type: "adaptive", effort };
+  }
+
+  const budget =
+    effort === "high"
+      ? 16000
+      : effort === "medium"
+        ? 8000
+        : effort === "low"
+          ? 4000
+          : 2048;
+  return { type: "enabled", budget_tokens: budget };
+}
+
+/**
+ * Gemini `thinkingConfig.thinkingBudget` value. Gemini accepts a raw token
+ * count (or -1 for "dynamic"); we map the normalized enum to budgets that
+ * match Google's published recommendations for the 2.5/3.x thinking models.
+ */
+export function toGeminiThinkingBudget(
+  effort: ReasoningEffort | undefined,
+): number | undefined {
+  if (!effort) return undefined;
+  if (typeof effort === "object" && "raw" in effort) {
+    return typeof effort.raw.thinkingBudget === "number"
+      ? (effort.raw.thinkingBudget as number)
+      : undefined;
+  }
+  if (typeof effort === "object" && "budgetTokens" in effort) {
+    return effort.budgetTokens;
+  }
+  switch (effort) {
+    case "minimal":
+      return 1024;
+    case "low":
+      return 4096;
+    case "medium":
+      return 8192;
+    case "high":
+      return 24576;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * xAI Grok `reasoning_effort` value (Chat Completions extension).
+ * Grok accepts `low | high` only — `minimal/medium` are bucketed.
+ */
+export function toXAIReasoningEffort(
+  effort: ReasoningEffort | undefined,
+): string | undefined {
+  if (!effort || typeof effort !== "string") return undefined;
+  return effort === "high" || effort === "medium" ? "high" : "low";
 }
 
 /**

--- a/packages/llm-sdk/src/adapters/openai.ts
+++ b/packages/llm-sdk/src/adapters/openai.ts
@@ -15,6 +15,7 @@ import {
   buildOpenAITokenParams,
   formatMessagesForOpenAI,
   formatTools,
+  isOpenAIReasoningModel,
   logProviderPayload,
   normalizeObjectJsonSchema,
   toOpenAIResponseFormat,
@@ -256,7 +257,22 @@ export class OpenAIAdapter implements LLMAdapter {
       request.config?.responseFormat,
     );
     const mcpTools = toOpenAIResponsesMcpTools(request.config?.mcpServers);
-    const reasoning = toOpenAIReasoning(request.config?.reasoningEffort);
+    // OpenAI's Responses API only accepts `reasoning` on reasoning-class
+    // models (o-series, gpt-5.x). Sending it to gpt-4o etc. returns
+    // `400 Unsupported parameter: 'reasoning.effort'`. Drop the field when
+    // the active model can't accept it — the request still goes through,
+    // the model just doesn't reason. Surface a warning so callers notice
+    // they may want to switch models.
+    const modelId = request.config?.model || this.model;
+    const reasoning = isOpenAIReasoningModel(modelId)
+      ? toOpenAIReasoning(request.config?.reasoningEffort)
+      : undefined;
+    if (request.config?.reasoningEffort && !isOpenAIReasoningModel(modelId)) {
+      console.warn(
+        `[llm-sdk] openai/${modelId} is not a reasoning model; ` +
+          "`reasoningEffort` is ignored. Use o1/o3/o4/gpt-5.x for reasoning.",
+      );
+    }
     const functionTools = this.buildResponsesTools(
       request.toolDefinitions ?? [],
     );

--- a/packages/llm-sdk/src/adapters/openai.ts
+++ b/packages/llm-sdk/src/adapters/openai.ts
@@ -19,6 +19,8 @@ import {
   normalizeObjectJsonSchema,
   toOpenAIResponseFormat,
   toOpenAIResponsesTextFormat,
+  toOpenAIResponsesMcpTools,
+  toOpenAIReasoning,
 } from "./base";
 
 /**
@@ -76,6 +78,23 @@ export class OpenAIAdapter implements LLMAdapter {
   }
 
   private shouldUseResponsesApi(request: ChatCompletionRequest): boolean {
+    // Responses API is required for MCP server passthrough and reasoning effort
+    // control — Chat Completions doesn't accept either field.
+    if (
+      (request.config?.mcpServers && request.config.mcpServers.length > 0) ||
+      request.config?.reasoningEffort !== undefined
+    ) {
+      // Other providers (Google, xAI, OpenRouter) share this adapter via the
+      // OpenAI-compatible endpoint but do not expose /v1/responses. Fail fast
+      // so a fallback chain can route to a provider that does support it.
+      if (this.provider !== "openai" && this.provider !== "azure") {
+        throw new Error(
+          `[llm-sdk] Provider "${this.provider}" does not support MCP servers or per-request reasoning effort. ` +
+            "Use OpenAI or Anthropic for these features.",
+        );
+      }
+      return true;
+    }
     return (
       request.providerToolOptions?.openai?.nativeToolSearch?.enabled === true &&
       request.providerToolOptions.openai.nativeToolSearch.useResponsesApi !==
@@ -184,7 +203,12 @@ export class OpenAIAdapter implements LLMAdapter {
         defer_loading: tool.deferLoading === true,
       }));
 
-    return [{ type: "tool_search" }, ...nativeTools];
+    // Only inject the `tool_search` meta-tool when the caller actually wired
+    // deferred tools — otherwise (MCP-only / reasoning-only flows) we omit it
+    // to keep the request shape minimal.
+    return nativeTools.length > 0
+      ? [{ type: "tool_search" }, ...nativeTools]
+      : [];
   }
 
   private parseResponsesResult(response: any): CompletionResult {
@@ -231,11 +255,18 @@ export class OpenAIAdapter implements LLMAdapter {
     const responsesTextFormat = toOpenAIResponsesTextFormat(
       request.config?.responseFormat,
     );
+    const mcpTools = toOpenAIResponsesMcpTools(request.config?.mcpServers);
+    const reasoning = toOpenAIReasoning(request.config?.reasoningEffort);
+    const functionTools = this.buildResponsesTools(
+      request.toolDefinitions ?? [],
+    );
+    const tools = [...functionTools, ...mcpTools];
+
     const payload = {
       model: request.config?.model || this.model,
       instructions: request.systemPrompt,
       input: this.buildResponsesInput(request),
-      tools: this.buildResponsesTools(request.toolDefinitions ?? []),
+      tools: tools.length > 0 ? tools : undefined,
       tool_choice:
         openaiToolOptions?.toolChoice === "required"
           ? "required"
@@ -246,6 +277,8 @@ export class OpenAIAdapter implements LLMAdapter {
       temperature: request.config?.temperature ?? this.config.temperature,
       max_output_tokens: request.config?.maxTokens ?? this.config.maxTokens,
       ...(responsesTextFormat ? { text: { format: responsesTextFormat } } : {}),
+      ...(reasoning ? { reasoning } : {}),
+      store: false,
       stream: false,
     };
 

--- a/packages/llm-sdk/src/core/generate-text.ts
+++ b/packages/llm-sdk/src/core/generate-text.ts
@@ -78,6 +78,8 @@ export async function generateText(
       temperature: params.temperature,
       maxTokens: params.maxTokens,
       responseFormat: params.responseFormat,
+      mcpServers: params.mcpServers,
+      reasoningEffort: params.reasoningEffort,
       signal,
     });
 

--- a/packages/llm-sdk/src/core/index.ts
+++ b/packages/llm-sdk/src/core/index.ts
@@ -32,6 +32,7 @@ export type {
   TextPart,
   ImagePart,
   FilePart,
+  AudioPart,
 
   // Tools
   Tool,

--- a/packages/llm-sdk/src/core/stream-events.ts
+++ b/packages/llm-sdk/src/core/stream-events.ts
@@ -305,12 +305,54 @@ export type ResponseFormat =
     };
 
 /**
+ * MCP (Model Context Protocol) server reference for a request.
+ *
+ * Vendor-neutral shape — each adapter translates to its provider's native
+ * field: OpenAI Responses `tools[type=mcp]`, Anthropic `mcp_servers` +
+ * `tools[type=mcp_toolset]` (beta `mcp-client-2025-11-20`), or local
+ * execution for adapters without native MCP.
+ */
+export interface McpServerConfig {
+  /** Human-readable label sent to the provider (also used as MCP server name). */
+  label: string;
+  /** MCP server endpoint (HTTP/SSE URL). */
+  url: string;
+  /** Additional HTTP headers; the `Authorization` value is also extracted for providers that take a separate token field. */
+  headers?: Record<string, string>;
+  /** Restrict the model to a subset of the MCP server's exposed tools. */
+  allowedTools?: string[];
+  /** Approval policy for tool invocation. Defaults to "never" (no human-in-the-loop). */
+  requireApproval?: "never" | "always";
+}
+
+/**
+ * Reasoning effort knob — normalized across providers.
+ *
+ * Maps to OpenAI Responses `reasoning.effort`, Anthropic `thinking`
+ * (adaptive+effort on Claude 4.6/4.7, budget_tokens on older models),
+ * Gemini `thinkingBudget`, xAI `reasoning_effort`. Adapters silently
+ * no-op when the underlying model doesn't support reasoning.
+ *
+ * Use the enum for the common case, or `{ budgetTokens }` / `{ raw }`
+ * for provider-specific escape hatches when full fidelity is required.
+ */
+export type ReasoningEffort =
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | { budgetTokens: number }
+  | { raw: Record<string, unknown> };
+
+/**
  * LLM configuration
  */
 export interface LLMConfig {
   temperature?: number;
   maxTokens?: number;
   responseFormat?: ResponseFormat;
+  mcpServers?: McpServerConfig[];
+  reasoningEffort?: ReasoningEffort;
 }
 
 /**

--- a/packages/llm-sdk/src/core/stream-text.ts
+++ b/packages/llm-sdk/src/core/stream-text.ts
@@ -97,6 +97,8 @@ export async function streamText(
           temperature: params.temperature,
           maxTokens: params.maxTokens,
           responseFormat: params.responseFormat,
+          mcpServers: params.mcpServers,
+          reasoningEffort: params.reasoningEffort,
           signal,
         })) {
           switch (chunk.type) {

--- a/packages/llm-sdk/src/core/types.ts
+++ b/packages/llm-sdk/src/core/types.ts
@@ -111,7 +111,7 @@ export interface ToolMessage {
 /**
  * Content parts for multimodal user messages
  */
-export type UserContentPart = TextPart | ImagePart | FilePart;
+export type UserContentPart = TextPart | ImagePart | FilePart | AudioPart;
 
 export interface TextPart {
   type: "text";
@@ -132,6 +132,16 @@ export interface FilePart {
   data: string;
   /** MIME type (e.g., 'application/pdf') */
   mimeType: string;
+}
+
+export interface AudioPart {
+  type: "input_audio";
+  input_audio: {
+    /** Base64-encoded audio data */
+    data: string;
+    /** Audio format (e.g., 'mp3', 'wav', 'ogg', 'webm', 'm4a', 'flac') */
+    format: string;
+  };
 }
 
 // ============================================
@@ -209,6 +219,10 @@ export interface DoGenerateParams {
   maxTokens?: number;
   /** Structured-output / JSON-mode request format (provider-translated) */
   responseFormat?: import("./stream-events").ResponseFormat;
+  /** MCP servers exposed to the model (provider-translated). */
+  mcpServers?: import("./stream-events").McpServerConfig[];
+  /** Reasoning/thinking effort knob (provider-translated). */
+  reasoningEffort?: import("./stream-events").ReasoningEffort;
   /** Abort signal */
   signal?: AbortSignal;
 }
@@ -316,6 +330,10 @@ export interface GenerateTextParams {
   maxTokens?: number;
   /** Structured-output / JSON-mode request format */
   responseFormat?: import("./stream-events").ResponseFormat;
+  /** MCP servers exposed to the model (provider-translated). */
+  mcpServers?: import("./stream-events").McpServerConfig[];
+  /** Reasoning/thinking effort knob (provider-translated). */
+  reasoningEffort?: import("./stream-events").ReasoningEffort;
   /** Abort signal */
   signal?: AbortSignal;
 }

--- a/packages/llm-sdk/src/index.ts
+++ b/packages/llm-sdk/src/index.ts
@@ -210,6 +210,10 @@ export type {
   // Web search types
   WebSearchConfig,
   Citation,
+  // Structured-output / MCP / reasoning request types
+  ResponseFormat,
+  McpServerConfig,
+  ReasoningEffort,
 } from "./core/stream-events";
 
 // Re-export utility functions

--- a/packages/llm-sdk/src/server/generate-result.ts
+++ b/packages/llm-sdk/src/server/generate-result.ts
@@ -19,6 +19,12 @@
 
 import type { DoneEventMessage } from "../core/stream-events";
 
+export interface GenerateUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+}
+
 export interface GenerateResultData {
   text: string;
   messages: DoneEventMessage[];
@@ -32,6 +38,7 @@ export interface GenerateResultData {
     result: unknown;
   }>;
   requiresAction: boolean;
+  usage?: GenerateUsage;
   error?: {
     message: string;
     code?: string;
@@ -104,6 +111,15 @@ export class GenerateResult {
    */
   get requiresAction(): boolean {
     return this.data.requiresAction;
+  }
+
+  /**
+   * Token usage for the call — present when the underlying provider emitted
+   * a usage payload on the `done` event. May be undefined for streaming
+   * responses that don't yield usage (e.g. mid-stream errors).
+   */
+  get usage(): GenerateUsage | undefined {
+    return this.data.usage;
   }
 
   /**

--- a/packages/llm-sdk/src/server/runtime.ts
+++ b/packages/llm-sdk/src/server/runtime.ts
@@ -12,6 +12,9 @@ import type {
   AIContent,
   ToolContext,
   WebSearchConfig,
+  ResponseFormat,
+  McpServerConfig,
+  ReasoningEffort,
 } from "../core/stream-events";
 import type { AIProvider } from "../providers/types";
 import { createMessage } from "../core/stream-events";
@@ -2151,6 +2154,61 @@ export class Runtime {
       requiresAction,
       error,
     });
+  }
+
+  /**
+   * One-shot non-streaming call bundling MCP servers, reasoning effort, and
+   * structured output. Thin ergonomic wrapper around `generate()` — uses the
+   * same adapter chain and the same translators, just expressed as a single
+   * prompt-in / text-out call.
+   *
+   * @example
+   * ```ts
+   * const result = await runtime.response({
+   *   prompt: "Extract FAQs from this conversation.",
+   *   mcpServers: [{ label: "kb", url: "https://kb.example.com/sse", headers: { Authorization: token } }],
+   *   reasoningEffort: "high",
+   *   responseFormat: { type: "json_schema", json_schema: { name: "faqs", schema } },
+   * });
+   * const data = JSON.parse(result.text);
+   * ```
+   */
+  async response(request: {
+    prompt: string;
+    systemPrompt?: string;
+    mcpServers?: McpServerConfig[];
+    reasoningEffort?: ReasoningEffort;
+    responseFormat?: ResponseFormat;
+    maxTokens?: number;
+    temperature?: number;
+  }): Promise<{
+    text: string;
+    toolCalls: Array<{
+      id: string;
+      name: string;
+      args: Record<string, unknown>;
+    }>;
+  }> {
+    const result = await this.generate({
+      messages: [{ role: "user", content: request.prompt }],
+      systemPrompt: request.systemPrompt,
+      config: {
+        temperature: request.temperature,
+        maxTokens: request.maxTokens,
+        responseFormat: request.responseFormat,
+        mcpServers: request.mcpServers,
+        reasoningEffort: request.reasoningEffort,
+      },
+    });
+
+    if (result.error) {
+      throw new Error(`[llm-sdk] response() failed: ${result.error.message}`);
+    }
+
+    return {
+      text: result.text,
+      toolCalls: result.toolCalls,
+    };
   }
 
   /**

--- a/packages/llm-sdk/src/server/runtime.ts
+++ b/packages/llm-sdk/src/server/runtime.ts
@@ -2087,6 +2087,9 @@ export class Runtime {
     const toolResults: Array<{ id: string; result: unknown }> = [];
     let messages: DoneEventMessage[] = [];
     let requiresAction = false;
+    let usage:
+      | { promptTokens: number; completionTokens: number; totalTokens: number }
+      | undefined;
     let error: { message: string; code?: string } | undefined;
 
     try {
@@ -2118,6 +2121,15 @@ export class Runtime {
           case "done":
             messages = event.messages || [];
             requiresAction = event.requiresAction || false;
+            if (event.usage) {
+              usage = {
+                promptTokens: event.usage.prompt_tokens,
+                completionTokens: event.usage.completion_tokens,
+                totalTokens:
+                  event.usage.total_tokens ??
+                  event.usage.prompt_tokens + event.usage.completion_tokens,
+              };
+            }
             break;
           case "error":
             error = { message: event.message, code: event.code };
@@ -2152,6 +2164,7 @@ export class Runtime {
       toolCalls,
       toolResults,
       requiresAction,
+      usage,
       error,
     });
   }
@@ -2188,6 +2201,11 @@ export class Runtime {
       name: string;
       args: Record<string, unknown>;
     }>;
+    usage?: {
+      promptTokens: number;
+      completionTokens: number;
+      totalTokens: number;
+    };
   }> {
     const result = await this.generate({
       messages: [{ role: "user", content: request.prompt }],
@@ -2208,6 +2226,7 @@ export class Runtime {
     return {
       text: result.text,
       toolCalls: result.toolCalls,
+      usage: result.usage,
     };
   }
 

--- a/packages/llm-sdk/src/server/types.ts
+++ b/packages/llm-sdk/src/server/types.ts
@@ -5,6 +5,8 @@ import type {
   ToolDefinition,
   ToolProfile,
   WebSearchConfig,
+  McpServerConfig,
+  ReasoningEffort,
 } from "../core/stream-events";
 import type { LLMAdapter } from "../adapters";
 import type { AIProvider } from "../providers/types";
@@ -227,6 +229,8 @@ export interface ChatRequest {
     temperature?: number;
     maxTokens?: number;
     responseFormat?: ResponseFormat;
+    mcpServers?: McpServerConfig[];
+    reasoningEffort?: ReasoningEffort;
   };
   /** System prompt override */
   systemPrompt?: string;


### PR DESCRIPTION
## Summary

Adds two missing per-request config fields — `mcpServers` and `reasoningEffort` — plus a `runtime.response()` ergonomic wrapper, by **extending the existing pipeline from #93** rather than forking a parallel surface.

**Supersedes #98.** That PR also targets this gap but reinvents structured-output builders (`text.format`, `output_config`) that already live in `adapters/base.ts`, and introduces a nested-shape regression on Anthropic's `output_config` that would cause `JSON.parse` failures when the fallback chain hits Claude. This PR uses the existing sanitizers from #93 directly so those bugs disappear by construction.

Driving use case: the `yourgpt-core-apis` `refactor/fallback-models-chaining` branch's self-learning extractor (`ChatbotJobController.js:1268-1285`) needs MCP-knowledgebase + JSON-schema + high reasoning in a single fallback-chain call.

## What's in

**Adapter changes**
- **OpenAI** — `shouldUseResponsesApi()` now also fires when `mcpServers` or `reasoningEffort` is set, routing through `/v1/responses` (the only OpenAI endpoint that accepts these fields). Function tools + `tools[type=mcp]` entries merged; `reasoning` block emitted; `store: false` for one-shot semantics. `tool_search` meta-tool no longer injected when no native tools are wired. **User role is `"user"` — not `"developer"` — for user prompts** (fixes the bug from #98).
- **Anthropic** — `buildRequestOptions()` now returns `{options, messages, betas}`. When MCP is set, emits the **`mcp-client-2025-11-20`** two-array shape (`mcp_servers` + separate `tools[type=mcp_toolset]` for `allowedTools`), routed through `client.beta.messages.*` so the SDK attaches the beta header. `reasoningEffort` maps via `toAnthropicThinking()` — **adaptive thinking on Claude 4.6/4.7**, explicit `budget_tokens` on older models.
- **Non-OpenAI/Azure baseUrls** (Google/xAI/OpenRouter share the OpenAI adapter via baseUrl) — throw a clear error when MCP/reasoning is set, so fallback chains with `retryableErrors: () => true` skip past them naturally.

**New translators in `adapters/base.ts`** (alongside existing structured-output sanitizers)
- `toOpenAIResponsesMcpTools` — Responses-API `tools[type=mcp]` entries
- `toAnthropicMcp` — splits into `mcp_servers` + `tools[mcp_toolset]`, hoists `Authorization: Bearer …` → bare `authorization_token`
- `toOpenAIReasoning` — `{ effort, summary: "auto" }` with `budgetTokens → effort` coercion
- `toAnthropicThinking` — adaptive for 4.6/4.7, `budget_tokens` for older
- `toGeminiThinkingBudget`, `toXAIReasoningEffort` — staged for the follow-up local-MCP work

**Surface plumbing** — `RequestLLMConfig` (adapter), `ChatRequest.config` (server), `DoGenerateParams` (modern provider), `GenerateTextParams` / `StreamTextParams` (top-level), `LLMConfig` — all gain `mcpServers?` + `reasoningEffort?`. Forwarded through `generate-text.ts` and `stream-text.ts` to `doGenerate()` / `doStream()`.

**New `AudioPart` content type** in `UserContentPart` union (passthrough wiring deferred — type is non-breaking).

**`runtime.response()`** — thin wrapper over `generate()`. Signature: `{ prompt, systemPrompt?, mcpServers?, reasoningEffort?, responseFormat?, maxTokens?, temperature? } → { text, toolCalls }`.

**Demo** — `examples/fallback-demo` adds `POST /response` exercising OpenAI → Anthropic fallback with KB MCP + `reasoningEffort: "high"` + FAQ JSON schema, mirroring the production self-learning case.

**Docs** (`docs(llm-sdk)` commit)
- `llm-sdk/structured-output.mdx` — new "MCP servers" and "Reasoning effort" sections with per-provider mapping tables
- New `llm-sdk/response.mdx` — full reference for the wrapper
- `llm-sdk/generate-text.mdx` + `stream-text.mdx` — params updated
- `providers/anthropic.mdx` — MCP + Extended thinking sections
- `providers/openai.mdx` — Responses-API routing section
- `packages/llm-sdk/README.md` — short overview block
- `meta.json` sidebar updated

## Deferred to follow-up PR

1. **Local-MCP-execution fallback** for Google/xAI/Fireworks/OpenRouter — needs a minimal MCP JSON-RPC client (~200 LOC) + per-adapter tool interception loops (~100 LOC each). Would 3× this PR's size. Today these providers throw cleanly and chains route past them.
2. **Modern provider path** (`providers/*/provider.ts`) `doGenerate()` accepts the new params in its type but doesn't read them yet — only the legacy adapter path (which `Runtime` uses) honors them today.
3. **`AudioPart` runtime passthrough** in OpenAI/Google adapters — type added, wiring mechanical, isolated to a separate PR.

## Compatibility

- No runtime breaking changes for existing callers (every new field is optional; behavior changes only when set)
- TS-level: `AudioPart` widens `UserContentPart` union — exhaustive `switch(part.type)` consumers need one new case
- Behavior shift: `store: false` now sent explicitly on `/v1/responses` calls (was implicit `true` before); intentional for one-shot semantics

## Test plan

- [x] `pnpm --filter @yourgpt/llm-sdk typecheck` clean
- [x] `pnpm --filter @yourgpt/llm-sdk build` clean
- [x] `tsc --noEmit` clean in `examples/fallback-demo`
- [ ] Live smoke: `POST /response` against the fallback-demo with real OPENAI_API_KEY / ANTHROPIC_API_KEY and an MCP endpoint
- [ ] Live smoke: equivalent call from `yourgpt-core-apis` `refactor/fallback-models-chaining` self-learning extractor once the SDK version is bumped

## Related

- Supersedes #98
- Builds on #93 (existing `responseFormat` sanitizers across providers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)