### PR TITLE
fix(llm-sdk): add defensive checks for json_schema in response format…

### DIFF
--- a/packages/llm-sdk/src/adapters/base.ts
+++ b/packages/llm-sdk/src/adapters/base.ts
@@ -349,6 +349,10 @@ export function toOpenAIResponseFormat(
 ): Record<string, unknown> | undefined {
   if (!rf) return undefined;
   if (rf.type === "json_object") return { type: "json_object" };
+  // Defensive: only proceed with json_schema if the field is actually present.
+  // JS callers can pass arbitrary `type` values (e.g. "text") that TS would reject —
+  // dereferencing rf.json_schema.name would otherwise throw "Cannot read properties of undefined (reading 'name')".
+  if (rf.type !== "json_schema" || !rf.json_schema) return undefined;
   return {
     type: "json_schema",
     json_schema: {
@@ -450,6 +454,7 @@ export function toOllamaFormat(
 ): string | Record<string, unknown> | undefined {
   if (!rf) return undefined;
   if (rf.type === "json_object") return "json";
+  if (rf.type !== "json_schema" || !rf.json_schema) return undefined;
   return rf.json_schema.schema;
 }
 


### PR DESCRIPTION
## Description

`toOpenAIResponseFormat` and `toOllamaFormat` in `packages/llm-sdk/src/adapters/base.ts` crashed with `Cannot read properties of undefined (reading 'name')` when callers passed a `response_format` whose `type` was anything other than `"json_object"` or `"json_schema"` (most commonly `{ type: "text" }`).

Both functions assumed any non-`json_object` input must be `json_schema` and dereferenced `rf.json_schema.name` / `rf.json_schema.schema` unconditionally. TypeScript callers are safe (the type only allows two variants), but JS consumers — and any caller forwarding raw OpenAI-style request bodies — can trivially trigger the crash.

Added a defensive guard mirroring the existing pattern in sibling functions (`toOpenAIResponsesTextFormat`, `toAnthropicOutputConfig`, `toGeminiSchema`): when `type !== "json_schema"` or `json_schema` is missing, return `undefined` so the LLM call proceeds with no response_format (default text behavior).

Fixes #

## Changes

- `toOpenAIResponseFormat`: added `if (rf.type !== "json_schema" || !rf.json_schema) return undefined;` before dereferencing `rf.json_schema`
- `toOllamaFormat`: same guard added before returning `rf.json_schema.schema`
- No behavior change for valid `json_object` and `json_schema` inputs — only previously-crashing invalid inputs now resolve cleanly to `undefined`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

- [x] I've tested this locally
- [ ] I've added/updated tests
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I've updated the documentation (if needed)
- [ ] I've added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)

N/A
