### PR TITLE
chore(security): npm supply-chain cooldown + pnpm 11.5.1

### DIFF
--- a/.github/workflows/dependency-age-gate.yml
+++ b/.github/workflows/dependency-age-gate.yml
@@ -1,0 +1,39 @@
+name: Dependency Age Gate
+
+# Supply-chain cooldown backstop: fails any PR that introduces a dependency
+# version published more recently than the cooldown window. Complements the
+# `minimumReleaseAge` setting in pnpm-workspace.yaml (which enforces the same
+# rule at install/resolution time on developer machines).
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cooldown:
+    name: Supply-chain cooldown
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need the base branch to diff the lockfile
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enforce dependency cooldown
+        env:
+          COOLDOWN_DAYS: "7" # keep in sync with minimumReleaseAge (days × 1440 = minutes)
+          BASE_REF: origin/${{ github.base_ref }}
+        run: node scripts/check-dependency-age.mjs

--- a/package.json
+++ b/package.json
@@ -35,13 +35,7 @@
     "turbo": "^2.0.0",
     "typescript": "^5.4.0"
   },
-  "pnpm": {
-    "overrides": {
-      "@types/react": "^18.2.0",
-      "@types/react-dom": "^18.2.0"
-    }
-  },
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@11.5.1",
   "engines": {
     "node": ">=20"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,35 @@ packages:
   - "apps/*"
   - "examples/*"
   - "examples/ollama-demo/*"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Supply-chain hardening
+# ─────────────────────────────────────────────────────────────────────────────
+# Cooldown: refuse to install ANY dependency version (including transitive)
+# published less than 7 days ago. Malicious package versions are almost always
+# detected and unpublished within hours–days, so this absorbs the blast radius
+# of a compromised release without holding back legit security patches for long.
+# Value is in MINUTES. 7 days = 7 × 24 × 60 = 10080. Requires pnpm >= 10.16.
+minimumReleaseAge: 10080
+
+# Packages exempt from the cooldown (e.g. our own first-party releases, which
+# we trust and may need to consume immediately). Supports names, globs, versions.
+minimumReleaseAgeExclude:
+  - "@yourgpt/*"
+
+# Dependency lifecycle (install/postinstall) scripts are blocked by default in
+# pnpm >= 10. These are the trusted native/build packages that legitimately need
+# to run a build step; everything else stays blocked. Review additions carefully.
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+  - "@parcel/watcher"
+  - workerd
+  - unrs-resolver
+  - msw
+
+# Migrated from package.json "pnpm.overrides" — pnpm >= 10 no longer reads the
+# "pnpm" field in package.json; overrides now live here.
+overrides:
+  "@types/react": "^18.2.0"
+  "@types/react-dom": "^18.2.0"

--- a/scripts/check-dependency-age.mjs
+++ b/scripts/check-dependency-age.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// ─────────────────────────────────────────────────────────────────────────────
+// Supply-chain cooldown CI gate (enforcement backstop)
+// ─────────────────────────────────────────────────────────────────────────────
+// Fails the build if a PR introduces any dependency version published more
+// recently than COOLDOWN_DAYS ago. This mirrors pnpm's `minimumReleaseAge`
+// (pnpm-workspace.yaml) but runs in CI, so it still catches a too-new version
+// even if a contributor used a different package manager, an older pnpm, or
+// hand-edited the lockfile. No third-party deps/actions — uses only Node builtins
+// to keep the gate itself off the supply-chain attack surface.
+//
+// Env:
+//   COOLDOWN_DAYS  cooldown window in days (default 7 — keep in sync with
+//                  minimumReleaseAge in pnpm-workspace.yaml: days × 1440 = minutes)
+//   BASE_REF       git ref to diff against (default origin/main)
+
+import { execSync } from "node:child_process";
+
+const COOLDOWN_DAYS = Number(process.env.COOLDOWN_DAYS || "7");
+const COOLDOWN_MS = COOLDOWN_DAYS * 24 * 60 * 60 * 1000;
+const BASE_REF = process.env.BASE_REF || "origin/main";
+const LOCKFILE = "pnpm-lock.yaml";
+
+// Names exempt from the cooldown — keep in sync with minimumReleaseAgeExclude.
+const EXCLUDE_PREFIXES = ["@yourgpt/"];
+
+let diff = "";
+try {
+  diff = execSync(`git diff ${BASE_REF}...HEAD -- ${LOCKFILE}`, {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+} catch (err) {
+  console.error(`Could not diff ${LOCKFILE} against ${BASE_REF}: ${err.message}`);
+  process.exit(1);
+}
+
+// pnpm-lock v9 package keys look like:
+//   '@scope/name@1.2.3':              (scoped, quoted)
+//   name@1.2.3:                       (unscoped)
+//   'react-dom@18.3.1(react@18.3.1)': (with peer suffix — base version captured)
+const KEY_RE = /^\+\s+'?((?:@[a-z0-9-._]+\/)?[a-z0-9-._]+)@([0-9][^():'\s]*)(?:\([^)]*\))?'?:/i;
+
+const specs = new Set();
+for (const line of diff.split("\n")) {
+  if (!line.startsWith("+")) continue;
+  const m = line.match(KEY_RE);
+  if (!m) continue;
+  const [, name, version] = m;
+  if (EXCLUDE_PREFIXES.some((p) => name.startsWith(p))) continue;
+  specs.add(`${name}@${version}`);
+}
+
+if (specs.size === 0) {
+  console.log("No new dependency versions introduced in the lockfile. ✅");
+  process.exit(0);
+}
+
+console.log(
+  `Checking ${specs.size} newly-introduced version(s) against a ${COOLDOWN_DAYS}-day cooldown…\n`,
+);
+
+const now = Date.now();
+const violations = [];
+const skipped = [];
+
+for (const spec of specs) {
+  const at = spec.lastIndexOf("@");
+  const name = spec.slice(0, at);
+  const version = spec.slice(at + 1);
+  const url = `https://registry.npmjs.org/${name.replace("/", "%2F")}`;
+
+  let meta;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      skipped.push(`${spec} (registry HTTP ${res.status})`);
+      continue;
+    }
+    meta = await res.json();
+  } catch (err) {
+    skipped.push(`${spec} (fetch failed: ${err.message})`);
+    continue;
+  }
+
+  const published = meta.time && meta.time[version];
+  if (!published) {
+    skipped.push(`${spec} (no publish timestamp)`);
+    continue;
+  }
+
+  const ageDays = (now - new Date(published).getTime()) / 86_400_000;
+  if (ageDays < COOLDOWN_DAYS) {
+    violations.push({ spec, ageDays, published });
+    console.log(`  ✗ ${spec} — published ${ageDays.toFixed(1)}d ago (< ${COOLDOWN_DAYS}d)`);
+  } else {
+    console.log(`  ✓ ${spec} — ${ageDays.toFixed(1)}d`);
+  }
+}
+
+if (skipped.length) {
+  console.log(`\nSkipped ${skipped.length} (could not verify):`);
+  for (const s of skipped) console.log(`  ? ${s}`);
+}
+
+if (violations.length) {
+  console.error(
+    `\n❌ ${violations.length} dependency version(s) are younger than the ${COOLDOWN_DAYS}-day cooldown:`,
+  );
+  for (const v of violations) {
+    console.error(`   - ${v.spec}  (published ${v.published})`);
+  }
+  console.error(
+    `\nLet them age past the cooldown, or add a reviewed exception to\n` +
+      `minimumReleaseAgeExclude in pnpm-workspace.yaml.`,
+  );
+  process.exit(1);
+}
+
+console.log(`\nAll newly-introduced versions satisfy the ${COOLDOWN_DAYS}-day cooldown. ✅`);


### PR DESCRIPTION
## Why

Rising npm supply-chain attacks (compromised maintainer accounts pushing malicious patch releases). This adds a **dependency cooldown** so we never install a version that's brand-new — the window where malicious releases are almost always caught and unpublished — plus a CI backstop to enforce it.

## What

**1. Cooldown gate (pnpm official `minimumReleaseAge`)** — `pnpm-workspace.yaml`
- `minimumReleaseAge: 10080` → refuse any dependency version (incl. transitive) published **< 7 days** ago.
- `minimumReleaseAgeExclude: ["@yourgpt/*"]` → our own first-party packages are exempt.
- Enforced at install/resolution time. Verified active: `pnpm install` now reports *"Verifying lockfile against supply-chain policies … ✓ passes."*

**2. pnpm 9.15.0 → 11.5.1** — `package.json` `packageManager`
- Required: `minimumReleaseAge` needs pnpm ≥ 10.16. (`pnpm/action-setup@v4` in CI reads this field automatically.)

**3. pnpm 11 migration fallout handled**
- Migrated `pnpm.overrides` (`@types/react*` pins) → `overrides:` in `pnpm-workspace.yaml` (pnpm ≥ 10 no longer reads the package.json `pnpm` field — these pins would have silently stopped applying).
- Added `onlyBuiltDependencies` allowlist for trusted native build scripts (`esbuild`, `sharp`, `@parcel/watcher`, `workerd`, `unrs-resolver`, `msw`) — pnpm ≥ 10 blocks dependency lifecycle scripts by default. Anything new requesting a build script is now blocked pending review.

**4. CI enforcement backstop** — `.github/workflows/dependency-age-gate.yml` + `scripts/check-dependency-age.mjs`
- Fails any PR introducing a dependency version younger than the cooldown, by checking npm publish dates against the lockfile diff. Catches bypasses the local setting can't (older pnpm, different package manager, hand-edited lockfile).
- Pure Node builtins — **no third-party actions/deps**, so the gate adds zero supply-chain surface.

## Notes for reviewers

- **Lockfile untouched** — no dependency version churn; the migrated overrides resolve identically.
- **Keep the two windows in sync**: `minimumReleaseAge: 10080` (minutes) and the workflow's `COOLDOWN_DAYS: "7"` are the same 7 days (days × 1440 = minutes). Noted in comments in both files.
- First CI run exercises pnpm 11's build-script blocking; if a job fails on a missing native build, add that package to `onlyBuiltDependencies`.
- Branched off `main` (not `beta`) to keep this isolated from the 8 in-flight beta release commits. **You'll likely want to land the same hardening on `beta` too.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)