### PR TITLE
fix(llm-sdk): refactor parameter handling for Gemini compatibility in…

### DIFF
--- a/packages/llm-sdk/src/adapters/anthropic.ts
+++ b/packages/llm-sdk/src/adapters/anthropic.ts
@@ -16,6 +16,7 @@ import {
   messageToAnthropicContent,
   logProviderPayload,
   toAnthropicOutputConfig,
+  parameterToJsonSchema,
   type AnthropicContentBlock,
 } from "./base";
 
@@ -415,11 +416,7 @@ export class AnthropicAdapter implements LLMAdapter {
               ? Object.fromEntries(
                   Object.entries(action.parameters).map(([key, param]) => [
                     key,
-                    {
-                      type: param.type,
-                      description: param.description,
-                      enum: param.enum,
-                    },
+                    parameterToJsonSchema(param),
                   ]),
                 )
               : {},

--- a/packages/llm-sdk/src/adapters/base.ts
+++ b/packages/llm-sdk/src/adapters/base.ts
@@ -179,7 +179,7 @@ export function formatMessages(
 /**
  * Convert ActionParameter to JSON Schema format recursively
  */
-function parameterToJsonSchema(param: {
+export function parameterToJsonSchema(param: {
   type: string;
   description?: string;
   enum?: string[];
@@ -444,6 +444,25 @@ export function toGeminiSchema(
   if (!rf || rf.type !== "json_schema") return undefined;
   return stripSchemaKeys(
     rf.json_schema.schema,
+    GEMINI_UNSUPPORTED_KEYS,
+  ) as Record<string, unknown>;
+}
+
+/**
+ * Convert an ActionParameter to a Gemini-compatible schema. Recurses into
+ * array `items` / object `properties` (via parameterToJsonSchema) so nested
+ * shapes are preserved, then strips keys Gemini's function-declaration schema
+ * rejects (e.g. `additionalProperties`).
+ */
+export function parameterToGeminiSchema(param: {
+  type: string;
+  description?: string;
+  enum?: string[];
+  items?: unknown;
+  properties?: Record<string, unknown>;
+}): Record<string, unknown> {
+  return stripSchemaKeys(
+    parameterToJsonSchema(param),
     GEMINI_UNSUPPORTED_KEYS,
   ) as Record<string, unknown>;
 }

--- a/packages/llm-sdk/src/adapters/google.ts
+++ b/packages/llm-sdk/src/adapters/google.ts
@@ -18,7 +18,12 @@ import type {
   ChatCompletionRequest,
   CompletionResult,
 } from "./base";
-import { formatTools, logProviderPayload, toGeminiSchema } from "./base";
+import {
+  formatTools,
+  logProviderPayload,
+  toGeminiSchema,
+  parameterToGeminiSchema,
+} from "./base";
 
 // ============================================
 // Types
@@ -234,11 +239,7 @@ function formatToolsForGemini(
             properties: Object.fromEntries(
               Object.entries(action.parameters).map(([key, param]) => [
                 key,
-                {
-                  type: param.type,
-                  description: param.description,
-                  enum: param.enum,
-                },
+                parameterToGeminiSchema(param),
               ]),
             ),
             required: Object.entries(action.parameters)


### PR DESCRIPTION
## Description

The Anthropic and Google adapters flattened nested tool-parameter schemas — their per-property mappers only copied `type`, `description`, and `enum`, silently dropping array `items` and nested object `properties`. As a result, models received tool definitions with no information about the inner shape of array/object parameters and improvised field names (e.g. sending `name`/`tel` instead of the schema-required `key`/`phone` for `show_generative_form`). This was deterministic, not model randomness.

Fixes #

## Changes

- **`base.ts`**: Exported the existing recursive `parameterToJsonSchema` converter, and added a new `parameterToGeminiSchema` helper (recurses into nested schemas via `parameterToJsonSchema`, then strips Gemini-unsupported keys like `additionalProperties`).
- **`anthropic.ts`**: Replaced the shallow `{ type, description, enum }` per-property mapper with `parameterToJsonSchema(param)`, so array `items` and nested object `properties` are preserved in the tool's `input_schema`.
- **`google.ts`**: Replaced the identical shallow mapper in `formatToolsForGemini` with `parameterToGeminiSchema(param)`, preserving nested schemas while staying compatible with Gemini's function-declaration schema.

_Not affected:_ OpenAI, xAI, Fireworks, OpenRouter, and TogetherAI already used the recursive `formatTools` (xAI/Fireworks/OpenRouter/TogetherAI delegate to the OpenAI adapter).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

Verified the converters against scalar and deeply-nested parameter schemas:
- Scalar params produce byte-identical output to the previous mapper (no behavioral change for simple fields).
- Nested params now carry the full `items`/`properties` tree (e.g. `sections[].fields[].key`) through to the model.
- Gemini output preserves nested `key` fields **and** has `additionalProperties` stripped (won't be rejected by Gemini's schema validator).
- `tsc --noEmit` passes clean on the package.

- [x] I've tested this locally
- [ ] I've added/updated tests
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I've updated the documentation (if needed)
- [ ] I've added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Screenshots (if applicable)
