### PR TITLE
fix(llm-sdk): enforce strict mode for additionalProperties in normali…

### DIFF
--- a/packages/llm-sdk/src/adapters/base.ts
+++ b/packages/llm-sdk/src/adapters/base.ts
@@ -271,9 +271,20 @@ export function normalizeObjectJsonSchema(
       : [];
     normalized.required = Array.from(new Set([...required, ...propertyKeys]));
 
-    if (normalized.additionalProperties === undefined) {
-      normalized.additionalProperties = false;
-    }
+    // Strict mode requires this to be exactly `false` on EVERY object, nested
+    // ones included. An explicit `additionalProperties: true` — what
+    // zodToJsonSchema emits for a free-form `z.record()`/`.passthrough()` field
+    // (e.g. Cal.com create_booking's `metadata`) — is rejected outright:
+    //   "In context=('properties','metadata'), 'additionalProperties' is
+    //    required to be supplied and to be false."
+    // So overwrite unconditionally rather than only filling in the undefined
+    // case; a truthy value is precisely the one that 400s.
+    //
+    // The cost is that genuinely open-ended objects can no longer accept
+    // arbitrary keys. With `properties: {}` that yields an object the model may
+    // only send empty — lossy, but strict mode has no way to express "any keys",
+    // and a degraded field beats a request the API refuses to accept at all.
+    normalized.additionalProperties = false;
   } else if (
     type === "array" &&
     normalized.items &&
@@ -281,6 +292,20 @@ export function normalizeObjectJsonSchema(
   ) {
     normalized.items = normalizeObjectJsonSchema(
       normalized.items as Record<string, unknown>,
+    );
+  }
+
+  // Composition keywords carry subschemas that are just as subject to the rules
+  // above, and they appear WITHOUT a sibling `type` (so neither branch above
+  // runs). An un-normalized object nested inside a union 400s exactly like a
+  // top-level one, so recurse regardless of `type`.
+  for (const keyword of ["anyOf", "oneOf", "allOf"]) {
+    const branches = normalized[keyword];
+    if (!Array.isArray(branches)) continue;
+    normalized[keyword] = branches.map((branch) =>
+      branch && typeof branch === "object"
+        ? normalizeObjectJsonSchema(branch as Record<string, unknown>)
+        : branch,
     );
   }
 


### PR DESCRIPTION
## Description

Function tools whose JSON Schema contains an explicit `additionalProperties: true`, or an object nested inside `anyOf`/`oneOf`/`allOf`, are rejected outright by the Responses API in strict mode. `normalizeObjectJsonSchema` did not cover either case, so those tools 400 before the request reaches the model.

Both failures reproduce against the live API on `gpt-5.6-luna`:

```
additionalProperties: true
→ 400 Invalid schema for function 'create_booking': In context=('properties','metadata'),
      'additionalProperties' is required to be supplied and to be false.

object inside anyOf
→ 400 Invalid schema for function 'create_booking': In context=('properties','u','anyOf','0'),
      'additionalProperties' is required to be supplied and to be false.
```

This hits any tool with a free-form field — `z.record()` / `.passthrough()`, which `zodToJsonSchema` emits as `additionalProperties: true` (e.g. Cal.com `create_booking`'s `metadata`) — or a union-typed field.

## Changes

- `normalizeObjectJsonSchema` now sets `additionalProperties: false` unconditionally instead of only when it is `undefined`. A truthy value is precisely the one the API rejects, so filling in the blank was never enough.
- Recurse into `anyOf` / `oneOf` / `allOf` subschemas. These carry no sibling `type`, so neither the object nor the array branch reached them and their contents went out un-normalized.

Scope: `normalizeObjectJsonSchema` has exactly one caller — `buildResponsesTools` in `adapters/openai.ts` — so this only affects the `/v1/responses` path (gpt-5.4+ and native tool search). Chat Completions is untouched.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

- [x] I've tested this locally
- [ ] I've added/updated tests
- [x] All existing tests pass

Verified against the live OpenAI API, plus unit-level checks of the pure function:

**Live** — both 400s above reproduced, then both return 200 after normalization. End-to-end on `gpt-5.6-luna` with a Cal.com-shaped tool (free-form `metadata` + `anyOf` attendee):

```
args: {"title":"Standup","metadata":{},"attendee":{"email":"alex@example.com"}}
text: "Booked "Standup" with alex@example.com."
```

**Negative control** — reverting this change on the same test reproduces `400 Invalid schema for function 'create_booking'`, confirming the fix is what makes it pass.

**Unit** — 12 cases: `true` overwritten at top level and nested; previously-`undefined` still filled (no regression); `anyOf`/`oneOf`/`allOf` branches normalized including inside properties and array `items`; non-object branches (`null`, strings, primitives) left untouched; 200-deep nesting without stack overflow.

**Regression** — a plain `get_weather` tool on `gpt-5.6` still works; typecheck clean; `turbo build` passes.

Note: the repo has no test runner, so the above were run as standalone scripts rather than committed tests.

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I've updated the documentation (if needed)
- [ ] I've added tests that prove my fix/feature works
- [x] New and existing tests pass locally

### Known tradeoff

Strict mode has no way to express "any keys", so a genuinely open-ended object now serialises as `additionalProperties: false` with empty `properties` — the model can only send `{}`. This is visible in the E2E output above (`"metadata":{}`).

Before this change the same schema 400'd the entire request, so no caller was successfully using such a field; this trades a hard failure for a degraded one. Worth a release note for anyone relying on `z.record()` payloads.

### Not covered

`$defs` / `$ref` subschemas are not normalized — a hand-written `inputSchema` using refs could still 400. Unreachable from the normal path, since this repo's `zodToJsonSchema` emits no `$ref`. Happy to fold it into the same loop if preferred.
